### PR TITLE
feat: Reply API 구현 (댓글 생성, 단일 조회, 부분 조회 API)

### DIFF
--- a/server/src/controller/reply-controller.ts
+++ b/server/src/controller/reply-controller.ts
@@ -1,0 +1,18 @@
+import HttpStatusCode from '@constants/http-status-code';
+import { NextFunction, Request, Response } from 'express';
+import ReplyService from '@service/reply-service';
+
+const ReplyController = {
+  async createMessage(req: Request, res: Response, next: NextFunction) {
+    const { userId } = req.user;
+    const { messageId, content } = req.body;
+    try {
+      await ReplyService.getInstance().createReply(Number(userId), Number(messageId), content);
+      res.status(HttpStatusCode.CREATED).send();
+    } catch (err) {
+      next(err);
+    }
+  }
+};
+
+export default ReplyController;

--- a/server/src/controller/reply-controller.ts
+++ b/server/src/controller/reply-controller.ts
@@ -7,8 +7,8 @@ const ReplyController = {
     const { userId } = req.user;
     const { messageId, content } = req.body;
     try {
-      await ReplyService.getInstance().createReply(Number(userId), Number(messageId), content);
-      res.status(HttpStatusCode.CREATED).send();
+      const replyId = await ReplyService.getInstance().createReply(Number(userId), Number(messageId), content);
+      res.status(HttpStatusCode.CREATED).json({ replyId });
     } catch (err) {
       next(err);
     }

--- a/server/src/controller/reply-controller.ts
+++ b/server/src/controller/reply-controller.ts
@@ -3,12 +3,21 @@ import { NextFunction, Request, Response } from 'express';
 import ReplyService from '@service/reply-service';
 
 const ReplyController = {
-  async createMessage(req: Request, res: Response, next: NextFunction) {
+  async createReply(req: Request, res: Response, next: NextFunction) {
     const { userId } = req.user;
     const { messageId, content } = req.body;
     try {
       await ReplyService.getInstance().createReply(Number(userId), Number(messageId), content);
       res.status(HttpStatusCode.CREATED).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+  async getReply(req: Request, res: Response, next: NextFunction) {
+    const { replyId } = req.params;
+    try {
+      const reply = await ReplyService.getInstance().getReply(Number(replyId));
+      res.status(HttpStatusCode.OK).json(reply);
     } catch (err) {
       next(err);
     }

--- a/server/src/controller/reply-controller.ts
+++ b/server/src/controller/reply-controller.ts
@@ -21,6 +21,19 @@ const ReplyController = {
     } catch (err) {
       next(err);
     }
+  },
+  async getReplies(req: Request, res: Response, next: NextFunction) {
+    const { offsetId } = req.params;
+    try {
+      if (!offsetId) {
+        const recentReplies = await ReplyService.getInstance().getRecentReplies();
+        res.status(HttpStatusCode.OK).json(recentReplies);
+      }
+      const replies = await ReplyService.getInstance().getRepliesByOffsetId(Number(offsetId));
+      res.status(HttpStatusCode.OK).json(replies);
+    } catch (err) {
+      next(err);
+    }
   }
 };
 

--- a/server/src/model/reply.ts
+++ b/server/src/model/reply.ts
@@ -12,6 +12,7 @@ import {
 import User from '@model/user';
 import Message from '@model/message';
 import ReplyReaction from '@model/reply-reaction';
+import { IsString } from 'class-validator';
 
 @Entity({ name: 'reply' })
 export default class Reply {
@@ -19,6 +20,7 @@ export default class Reply {
   replyId: number;
 
   @Column()
+  @IsString()
   content: string;
 
   @CreateDateColumn()

--- a/server/src/router/api.ts
+++ b/server/src/router/api.ts
@@ -3,11 +3,13 @@ import userRouter from '@router/user-router';
 import messageRouter from '@router/message-router';
 import chatroomRouter from '@router/chatroom-router';
 import userChatroomRouter from '@router/user-chatroom-router';
+import replyRouter from '@router/reply-router';
 
 const router = express.Router();
 router.use('/messages', messageRouter);
 router.use('/users', userRouter);
 router.use('/chatrooms', chatroomRouter);
 router.use('/user-chatrooms', userChatroomRouter);
+router.use('/replies', replyRouter);
 
 export default router;

--- a/server/src/router/reply-router.ts
+++ b/server/src/router/reply-router.ts
@@ -3,6 +3,7 @@ import ReplyController from '@controller/reply-controller';
 
 const router = express.Router();
 
-router.post('/', ReplyController.createMessage);
+router.post('/', ReplyController.createReply);
+router.get('/:replyId', ReplyController.getReply);
 
 export default router;

--- a/server/src/router/reply-router.ts
+++ b/server/src/router/reply-router.ts
@@ -4,6 +4,7 @@ import ReplyController from '@controller/reply-controller';
 const router = express.Router();
 
 router.post('/', ReplyController.createReply);
-router.get('/:replyId', ReplyController.getReply);
+router.get('/', ReplyController.getReplies);
+router.get('/:offsetId', ReplyController.getReplies);
 
 export default router;

--- a/server/src/router/reply-router.ts
+++ b/server/src/router/reply-router.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import ReplyController from '@controller/reply-controller';
+
+const router = express.Router();
+
+router.post('/', ReplyController.createMessage);
+
+export default router;

--- a/server/src/service/reply-service.ts
+++ b/server/src/service/reply-service.ts
@@ -1,0 +1,44 @@
+import { getCustomRepository } from 'typeorm';
+import ReplyRepository from '@repository/reply-repository';
+import UserRepository from '@repository/user-repository';
+import MessageRepository from '@repository/message-repository';
+import validator from '@utils/validator';
+import NotFoundError from '@error/not-found-error';
+
+class ReplyService {
+  static instance: ReplyService;
+
+  replyRepository: ReplyRepository;
+
+  userRepository: UserRepository;
+
+  messageRepository: MessageRepository;
+
+  constructor() {
+    this.replyRepository = getCustomRepository(ReplyRepository);
+    this.userRepository = getCustomRepository(UserRepository);
+    this.messageRepository = getCustomRepository(MessageRepository);
+  }
+
+  static getInstance(): ReplyService {
+    if (!ReplyService.instance) {
+      ReplyService.instance = new ReplyService();
+    }
+    return ReplyService.instance;
+  }
+
+  async createReply(userId: number, messageId: number, content: string) {
+    const user = await this.userRepository.findOne(userId);
+    const message = await this.messageRepository.findOne(messageId);
+
+    if (!user || !message) {
+      throw new NotFoundError();
+    }
+
+    const reply = this.replyRepository.create({ user, message, content });
+    await validator(reply);
+    await this.replyRepository.save(reply);
+  }
+}
+
+export default ReplyService;

--- a/server/src/service/reply-service.ts
+++ b/server/src/service/reply-service.ts
@@ -62,6 +62,51 @@ class ReplyService {
     return { ...reply, replyReactions: this.formattingReplyReactions(replyReactions) };
   }
 
+  async getRepliesByOffsetId(offsetId: number) {
+    const replies = await this.replyRepository
+      .createQueryBuilder('reply')
+      .leftJoinAndSelect('reply.user', 'writer')
+      .leftJoinAndSelect('reply.replyReactions', 'replyReactions')
+      .leftJoinAndSelect('replyReactions.user', 'user')
+      .leftJoinAndSelect('replyReactions.reaction', 'reaction')
+      .select(['reply.replyId', 'reply.content', 'reply.createdAt', 'reply.updatedAt'])
+      .addSelect(['writer.userId', 'writer.profileUri', 'writer.displayName'])
+      .addSelect(['replyReactions', 'user', 'reaction'])
+      .where('reply.replyId < :offsetId', { offsetId })
+      .orderBy('reply.replyId', 'DESC')
+      .take(10)
+      .getMany();
+
+    const formattedReplies = replies.map((reply) => {
+      const { replyReactions } = { ...reply };
+      return { ...reply, replyReactions: this.formattingReplyReactions(replyReactions) };
+    });
+
+    return formattedReplies;
+  }
+
+  async getRecentReplies() {
+    const replies = await this.replyRepository
+      .createQueryBuilder('reply')
+      .leftJoinAndSelect('reply.user', 'writer')
+      .leftJoinAndSelect('reply.replyReactions', 'replyReactions')
+      .leftJoinAndSelect('replyReactions.user', 'user')
+      .leftJoinAndSelect('replyReactions.reaction', 'reaction')
+      .select(['reply.replyId', 'reply.content', 'reply.createdAt', 'reply.updatedAt'])
+      .addSelect(['writer.userId', 'writer.profileUri', 'writer.displayName'])
+      .addSelect(['replyReactions', 'user', 'reaction'])
+      .orderBy('reply.replyId', 'DESC')
+      .take(10)
+      .getMany();
+
+    const formattedReplies = replies.map((reply) => {
+      const { replyReactions } = { ...reply };
+      return { ...reply, replyReactions: this.formattingReplyReactions(replyReactions) };
+    });
+
+    return formattedReplies;
+  }
+
   private formattingReplyReactions(replyReactions: any[]) {
     const reactions = {};
 

--- a/server/src/service/reply-service.ts
+++ b/server/src/service/reply-service.ts
@@ -37,7 +37,8 @@ class ReplyService {
 
     const reply = this.replyRepository.create({ user, message, content });
     await validator(reply);
-    await this.replyRepository.save(reply);
+    const newReply = await this.replyRepository.save(reply);
+    return newReply.replyId;
   }
 
   async getReply(replyId: number) {


### PR DESCRIPTION
## :bookmark_tabs: 제목

Reply API 구현 (댓글 생성, 단일 조회, 부분 조회 API)

resolved: #31  resolved: #26 resolved: #28

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 댓글 생성 API 구현
- [x] 댓글 단일 조회 API 구현
- [x] 댓글 부분 조회 API 구현


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 댓글 단일 조회 API 관련 Service와 Controller를 구현하기는 했지만 현재 Router에서 사용하고 있지는 않습니다.
- 댓글 부분 조회 API는 offsetId를 이용해서 offsetId보다 전에 생성된 댓글 10개의 정보를 가져오도록 구현했습니다.
- 댓글 부분 조회 API 호출 시 offsetId가 없다면 가장 최신 댓글 10개의 정보를 가져오도록 구현했습니다.
