### PR TITLE
feat: 유저 채팅방 조회 API 수정 (자신과의 DM ProfileImg 추가)

### DIFF
--- a/server/src/service/user-chatroom-service.ts
+++ b/server/src/service/user-chatroom-service.ts
@@ -104,7 +104,13 @@ class UserChatroomService {
       return String();
     }
 
-    const [chatProfileImg] = chatrooms.filter((chatroom) => chatroom.user.userId !== userId).map((chatroom) => chatroom.user.profileUri);
+    const users = chatrooms.map((chatroom) => chatroom.user);
+
+    if (users.every((user) => user.userId === userId)) {
+      return users[0].profileUri;
+    }
+
+    const [chatProfileImg] = users.filter((user) => user.userId !== userId).map((user) => user.profileUri);
 
     return chatProfileImg;
   }


### PR DESCRIPTION
## :bookmark_tabs: 제목

유저 채팅방 조회 API 수정

관련 이슈: #95 

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 자신과의 DM ProfileImg 추가
- [x] DM title을 상대방 displayName으로 설정


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 자신과의 DM인 경우 채팅방 정보에 본인의 ProfileUri를 포함하도록 수정했습니다.
- 채팅방 조회 시 해당 DM에 속해있는 사용자의 이름을 title로 보내주도록 수정했습니다.
- 자기 자신과의 DM인 경우 자신의 displayName을 title로 설정했습니다.