### PR TITLE
feat: 채널/DM 생성 API 분리

### DIFF
--- a/server/src/common/constants/chat-type.ts
+++ b/server/src/common/constants/chat-type.ts
@@ -1,0 +1,5 @@
+const enum ChatType {
+  DM = 'DM',
+  Channel = 'Channel'
+}
+export default ChatType;

--- a/server/src/common/constants/default-section-name.ts
+++ b/server/src/common/constants/default-section-name.ts
@@ -1,6 +1,7 @@
-const DefaultSectionName = {
-  Channels: 'Channels',
-  DirectMessages: 'DirectMessages'
-};
+const enum DefaultSectionName {
+  Channels = 'Channels',
+  DirectMessages = 'Direct Messages',
+  Starred = 'Starred'
+}
 
 export default DefaultSectionName;

--- a/server/src/common/constants/http-status-code.ts
+++ b/server/src/common/constants/http-status-code.ts
@@ -1,13 +1,13 @@
-const HttpStatusCode = {
-  OK: 200,
-  CREATED: 201,
-  NO_CONTENT: 204,
-  BAD_REQUEST: 400,
-  UNAUTHORIZED: 401,
-  FORBIDDEN: 403,
-  NOT_FOUND: 404,
-  CONFLICT: 409,
-  INTERNAL_SERVER_ERROR: 500
-};
+const enum HttpStatusCode {
+  OK = 200,
+  CREATED = 201,
+  NO_CONTENT = 204,
+  BAD_REQUEST = 400,
+  UNAUTHORIZED = 401,
+  FORBIDDEN = 403,
+  NOT_FOUND = 404,
+  CONFLICT = 409,
+  INTERNAL_SERVER_ERROR = 500
+}
 
 export default HttpStatusCode;

--- a/server/src/controller/chatroom-controller.ts
+++ b/server/src/controller/chatroom-controller.ts
@@ -7,8 +7,8 @@ const ChatroomController = {
     try {
       const { userId } = req.user;
       const { title, description, isPrivate, chatType } = req.body;
-      await ChatroomService.getInstance().createChatroom({ userId, title, description, isPrivate, chatType });
-      res.status(HttpStatusCode.CREATED).send();
+      const chatroomId = await ChatroomService.getInstance().createChatroom({ userId, title, description, isPrivate, chatType });
+      res.status(HttpStatusCode.CREATED).json({ chatroomId });
     } catch (err) {
       next(err);
     }

--- a/server/src/controller/chatroom-controller.ts
+++ b/server/src/controller/chatroom-controller.ts
@@ -3,11 +3,21 @@ import ChatroomService from '@service/chatroom-service';
 import { NextFunction, Request, Response } from 'express';
 
 const ChatroomController = {
-  async createChatroom(req: Request, res: Response, next: NextFunction) {
+  async createChannel(req: Request, res: Response, next: NextFunction) {
     try {
       const { userId } = req.user;
-      const { title, description, isPrivate, chatType } = req.body;
-      const chatroomId = await ChatroomService.getInstance().createChatroom({ userId, title, description, isPrivate, chatType });
+      const { title, description, isPrivate } = req.body;
+      const chatroomId = await ChatroomService.getInstance().createChannel({ userId: Number(userId), title, description, isPrivate });
+      res.status(HttpStatusCode.CREATED).json({ chatroomId });
+    } catch (err) {
+      next(err);
+    }
+  },
+  async createDM(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { userId } = req.user;
+      const { invitedUserId } = req.body;
+      const chatroomId = await ChatroomService.getInstance().createDM(Number(userId), Number(invitedUserId));
       res.status(HttpStatusCode.CREATED).json({ chatroomId });
     } catch (err) {
       next(err);

--- a/server/src/model/chatroom.ts
+++ b/server/src/model/chatroom.ts
@@ -2,6 +2,7 @@ import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateCol
 import { IsBoolean, IsIn, IsString } from 'class-validator';
 import UserChatroom from '@model/user-chatroom';
 import Message from '@model/message';
+import ChatType from '@constants/chat-type';
 
 @Entity({ name: 'chatroom' })
 export default class Chatroom {
@@ -20,7 +21,7 @@ export default class Chatroom {
   isPrivate: boolean;
 
   @Column()
-  @IsIn(['DM', 'Channel'])
+  @IsIn([ChatType.DM, ChatType.Channel])
   chatType: string;
 
   @Column({ nullable: true })

--- a/server/src/router/chatroom-router.ts
+++ b/server/src/router/chatroom-router.ts
@@ -3,7 +3,8 @@ import ChatroomController from '@controller/chatroom-controller';
 
 const router = express.Router();
 
-router.post('/', ChatroomController.createChatroom);
+router.post('/channel', ChatroomController.createChannel);
+router.post('/dm', ChatroomController.createDM);
 router.get('/:chatroomId', ChatroomController.getChatroomInfo);
 router.patch('/:chatroomId', ChatroomController.updateChatroom);
 router.delete('/:chatroomId', ChatroomController.deleteChatroom);

--- a/server/src/seeds/chatroom.ts
+++ b/server/src/seeds/chatroom.ts
@@ -1,6 +1,7 @@
 import { Factory, Seeder } from 'typeorm-seeding';
 import { Connection } from 'typeorm';
-import Chatroom from '../model/chatroom';
+import ChatType from '@constants/chat-type';
+import Chatroom from '@model/chatroom';
 
 export default class CreateChatrooms implements Seeder {
   public async run(factory: Factory, connection: Connection): Promise<any> {
@@ -8,7 +9,7 @@ export default class CreateChatrooms implements Seeder {
       {
         title: 'random',
         isPrivate: false,
-        chatType: 'Channel'
+        chatType: ChatType.Channel
       }
     ];
     const res = await connection.getRepository(Chatroom).findOne(chatroomData[0]);

--- a/server/src/service/chatroom-service.ts
+++ b/server/src/service/chatroom-service.ts
@@ -3,30 +3,12 @@ import { Transactional } from 'typeorm-transactional-cls-hooked';
 import ChatroomRepository from '@repository/chatroom-repository';
 import UserRepository from '@repository/user-repository';
 import UserChatroomRepository from '@repository/user-chatroom-repository';
-import User from '@model/user';
-import Chatroom from '@model/chatroom';
 import validator from '@utils/validator';
 import BadRequestError from '@error/bad-request-error';
 import NotFoundError from '@error/not-found-error';
 import ChatType from '@constants/chat-type';
 import DefaultSectionName from '@constants/default-section-name';
-
-interface saveChatroomParams {
-  title: string;
-  description: string;
-  isPrivate: boolean;
-  chatType: ChatType.DM | ChatType.Channel;
-}
-
-interface createChatroomParams extends saveChatroomParams {
-  userId: number;
-}
-
-interface saveUserChatroomParams {
-  sectionName: string;
-  user: User;
-  chatroom: Chatroom;
-}
+import ConflictError from '@error/conflict-error';
 
 class ChatroomService {
   static instance: ChatroomService;
@@ -51,7 +33,7 @@ class ChatroomService {
   }
 
   @Transactional()
-  async createChatroom({ userId, title, description, isPrivate, chatType }: createChatroomParams) {
+  async createChannel({ userId, title, description, isPrivate }) {
     const user = await this.userRepository.findOne(userId);
     const chatroom = await this.chatroomRepository.findByTitle(title);
 
@@ -59,21 +41,67 @@ class ChatroomService {
       throw new BadRequestError();
     }
 
-    const sectionName = chatType === ChatType.DM ? DefaultSectionName.DirectMessages : DefaultSectionName.Channels;
-
-    const newChatroom = await this.saveChatroom({ title, description, isPrivate, chatType });
-    await this.saveUserChatroom({ sectionName, user, chatroom: newChatroom });
+    const newChatroom = await this.saveChatroom({ title, description, isPrivate, chatType: ChatType.Channel });
+    await this.saveUserChatroom({ sectionName: DefaultSectionName.Channels, user, chatroom: newChatroom });
     return newChatroom.chatroomId;
   }
 
-  private async saveChatroom({ title, description, isPrivate, chatType }: saveChatroomParams) {
+  @Transactional()
+  async createDM(userId: number, invitedUserId: number) {
+    const user = await this.userRepository.findOne(userId);
+    const invitedUser = await this.userRepository.findOne(invitedUserId);
+
+    if (!user || !invitedUser) {
+      throw new BadRequestError();
+    }
+
+    await this.validateExistsDM(userId, invitedUserId);
+
+    const newChatroom = await this.saveChatroom({ title: null, description: null, isPrivate: true, chatType: ChatType.DM });
+    await this.saveUserChatroom({ sectionName: DefaultSectionName.DirectMessages, user, chatroom: newChatroom });
+    await this.saveUserChatroom({ sectionName: DefaultSectionName.DirectMessages, user: invitedUser, chatroom: newChatroom });
+    return newChatroom.chatroomId;
+  }
+
+  private async validateExistsDM(userId: number, invitedUserId: number) {
+    const userChatrooms = await this.userChatroomRepository
+      .createQueryBuilder('userChatroom')
+      .leftJoinAndSelect('userChatroom.chatroom', 'chatroom')
+      .where('userChatroom.user.userId = :userId', { userId })
+      .andWhere('chatroom.chatType = :chatType', { chatType: ChatType.DM })
+      .getMany();
+
+    await Promise.all(
+      userChatrooms.map(async (userChatroom) => {
+        const { chatroomId } = userChatroom.chatroom;
+        const otherUserChatroom = await this.userChatroomRepository
+          .createQueryBuilder('userChatroom')
+          .leftJoinAndSelect('userChatroom.chatroom', 'chatroom')
+          .leftJoinAndSelect('userChatroom.user', 'user')
+          .where('chatroom.chatroomId = :chatroomId', { chatroomId })
+          .andWhere('userChatroom.user.userId != :userId', { userId })
+          .andWhere('chatroom.chatType = :chatType', { chatType: ChatType.DM })
+          .getOne();
+
+        if (otherUserChatroom && otherUserChatroom.user.userId === invitedUserId) {
+          throw new ConflictError();
+        }
+      })
+    );
+  }
+
+  private async saveChatroom({ title, description, isPrivate, chatType }) {
     const chatroom = this.chatroomRepository.create({ title, description, isPrivate, chatType });
-    await validator(chatroom);
+
+    if (chatType === ChatType.Channel) {
+      await validator(chatroom);
+    }
+
     const newChatroom = await this.chatroomRepository.save(chatroom);
     return newChatroom;
   }
 
-  private async saveUserChatroom({ sectionName, user, chatroom }: saveUserChatroomParams) {
+  private async saveUserChatroom({ sectionName, user, chatroom }) {
     const userChatroom = this.userChatroomRepository.create({ sectionName, user, chatroom });
     await validator(userChatroom);
     const newUserChatroom = await this.userChatroomRepository.save(userChatroom);

--- a/server/src/service/chatroom-service.ts
+++ b/server/src/service/chatroom-service.ts
@@ -8,12 +8,14 @@ import Chatroom from '@model/chatroom';
 import validator from '@utils/validator';
 import BadRequestError from '@error/bad-request-error';
 import NotFoundError from '@error/not-found-error';
+import ChatType from '@constants/chat-type';
+import DefaultSectionName from '@constants/default-section-name';
 
 interface saveChatroomParams {
   title: string;
   description: string;
   isPrivate: boolean;
-  chatType: 'DM' | 'Channel';
+  chatType: ChatType.DM | ChatType.Channel;
 }
 
 interface createChatroomParams extends saveChatroomParams {
@@ -52,14 +54,16 @@ class ChatroomService {
   async createChatroom({ userId, title, description, isPrivate, chatType }: createChatroomParams) {
     const user = await this.userRepository.findOne(userId);
     const chatroom = await this.chatroomRepository.findByTitle(title);
-    const sectionName = chatType === 'DM' ? 'Direct Message' : 'Channels';
 
     if (chatroom || !user) {
       throw new BadRequestError();
     }
 
+    const sectionName = chatType === ChatType.DM ? DefaultSectionName.DirectMessages : DefaultSectionName.Channels;
+
     const newChatroom = await this.saveChatroom({ title, description, isPrivate, chatType });
     await this.saveUserChatroom({ sectionName, user, chatroom: newChatroom });
+    return newChatroom.chatroomId;
   }
 
   private async saveChatroom({ title, description, isPrivate, chatType }: saveChatroomParams) {

--- a/server/src/service/user-chatroom-service.ts
+++ b/server/src/service/user-chatroom-service.ts
@@ -7,6 +7,8 @@ import UserRepository from '@repository/user-repository';
 import ChatroomRepository from '@repository/chatroom-repository';
 import BadRequestError from '@error/bad-request-error';
 import validator from '@utils/validator';
+import ChatType from '@constants/chat-type';
+import DefaultSectionName from '@constants/default-section-name';
 
 class UserChatroomService {
   static instance: UserChatroomService;
@@ -45,9 +47,9 @@ class UserChatroomService {
       throw new NotFoundError();
     }
 
-    const starred = this.classifyChannelsBySectionName(userChatrooms, 'Starred');
+    const starred = this.classifyChannelsBySectionName(userChatrooms, DefaultSectionName.Starred);
     const otherSections = await this.classifyOtherSections(userChatrooms, userId);
-    const channels = this.classifyChannelsBySectionName(userChatrooms, 'Channels');
+    const channels = this.classifyChannelsBySectionName(userChatrooms, DefaultSectionName.Channels);
     const directMessages = await this.classifyDirectMessages(userChatrooms, userId);
 
     return { starred, otherSections, channels, directMessages };
@@ -81,7 +83,7 @@ class UserChatroomService {
   private async classifyDirectMessages(userChatrooms: any[], userId: number) {
     const directMessages = await Promise.all(
       userChatrooms
-        .filter((userChatroom) => userChatroom.sectionName === 'Direct Message')
+        .filter((userChatroom) => userChatroom.sectionName === DefaultSectionName.DirectMessages)
         .map(async (userChatroom) => {
           const { chatroomId, chatType } = userChatroom.chatroom;
           const { title, chatProfileImg } = await this.findTitleAndImg(userChatroom, userId);
@@ -175,7 +177,7 @@ class UserChatroomService {
   }
 
   private async saveChatroom(user, chatroom) {
-    const sectionName = chatroom.chatType === 'DM' ? 'Direct Message' : 'Channels';
+    const sectionName = chatroom.chatType === ChatType.DM ? DefaultSectionName.DirectMessages : DefaultSectionName.Channels;
     const newUserChatroom = this.userChatroomRepository.create({ user, chatroom, sectionName });
     await validator(newUserChatroom);
     await this.userChatroomRepository.save(newUserChatroom);

--- a/server/src/service/user-service.ts
+++ b/server/src/service/user-service.ts
@@ -6,6 +6,7 @@ import NotFoundError from '@error/not-found-error';
 import Chatroom from '@model/chatroom';
 import User from '@model/user';
 import DefaultSectionName from '@constants/default-section-name';
+import ChatType from '@constants/chat-type';
 
 class UserService {
   static instance: UserService;
@@ -76,7 +77,7 @@ class UserService {
   }
 
   private async createDirectMessage() {
-    const newDirectMessage = await this.chatroomRepository.save({ isPrivate: true, chatType: 'DM' });
+    const newDirectMessage = await this.chatroomRepository.save({ isPrivate: true, chatType: ChatType.DM });
     return newDirectMessage;
   }
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

채널/DM 생성 API 분리

관련 이슈: #95 


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 채널/DM 생성 API 분리
    - [x] 채널 생성 API
    - [x] DM 생성 API


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 채널/DM 생성 API를 채널 생성 API와 DM 생성 API로 분리했습니다.
```
POST /api/chatrooms/dm
{
    "invitedUserId": "number"
}
```

```
POST /api/chatrooms/channel
{
    "title": "string",
    "desctiption": "string",
    "isPrivate": true
}
```
- 소스코드 내 상수를 enum으로 관리하도록 리팩토링을 진행했습니다.