### PR TITLE
feat: chatroom 속 컴포넌트 추가 및 메시지 전송 로직 구현

### DIFF
--- a/client/src/components/atoms/Input/Input.tsx
+++ b/client/src/components/atoms/Input/Input.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
 
+const ENTER_KEYCODE = 13;
+
 interface InputProps {
   title?: string;
   isThread?: boolean;
   content: string;
   setContent: any;
+  keyPressEnter: any;
 }
 
 const StyledInput = styled.input<any>`
@@ -15,11 +18,22 @@ const StyledInput = styled.input<any>`
   outline: none;
 `;
 
-const Input: React.FC<InputProps> = ({ title, isThread = false, content, setContent, ...props }) => {
+const Input: React.FC<InputProps> = ({ title, isThread = false, content, setContent, keyPressEnter, ...props }) => {
+  const handlingKeyPressEnter = (e: any) => {
+    if (e.charCode === ENTER_KEYCODE) keyPressEnter(e.target.value);
+  };
   const handlingChange = (e: any) => {
     setContent(e.target.value);
   };
-  return <StyledInput placeholder={isThread ? 'Reply...' : `Send a message to #${title}`} value={content} onChange={handlingChange} {...props} />;
+  return (
+    <StyledInput
+      placeholder={isThread ? 'Reply...' : `Send a message to #${title}`}
+      value={content}
+      onKeyPress={handlingKeyPressEnter}
+      onChange={handlingChange}
+      {...props}
+    />
+  );
 };
 
 export { Input, InputProps };

--- a/client/src/components/molecules/InputMessage/InputMessage.tsx
+++ b/client/src/components/molecules/InputMessage/InputMessage.tsx
@@ -36,12 +36,13 @@ const InputMessage: React.FC<InputMessageProps> = ({ children, title, isThread, 
 
   const sendMessage = () => {
     createMessage({ content, chatroomId: chatRoomId });
+    setContent('');
   };
 
   return (
     <InputMessageContainer {...props}>
       <InputWrap>
-        <Input isThread={isThread} title={title} content={content} setContent={setContent} />
+        <Input isThread={isThread} title={title} content={content} keyPressEnter={sendMessage} setContent={setContent} />
       </InputWrap>
       <ButtonWrap>
         <SendMessageButton isActive={true} sendMessage={sendMessage} />

--- a/client/src/components/molecules/UserBox/UserBox.tsx
+++ b/client/src/components/molecules/UserBox/UserBox.tsx
@@ -30,16 +30,16 @@ const Text = styled.div<any>`
 
 const UserBox: React.FC<UserBoxProps> = ({ member, ...props }) => {
   const memberNum = member.length;
-  const profileImgs: string[] = new Array(3);
+  const displayMembers: object[] = new Array(3);
   const loopValue = memberNum > 3 ? 3 : memberNum;
 
   for (let i = 0; i < loopValue; i += 1) {
-    profileImgs.push(member[i].profileUri);
+    displayMembers.push({ id: member[i].userId, profileUri: member[i].profileUri });
   }
 
-  const createProfileImg = profileImgs.map((profileImg) => (
-    <ProfileImgWrap>
-      <ProfileImg src={profileImg} />
+  const createProfileImg = displayMembers.map((Member: any) => (
+    <ProfileImgWrap key={Member.id}>
+      <ProfileImg src={Member.profileUri} />
     </ProfileImgWrap>
   ));
 

--- a/client/src/components/molecules/UserBox/UserBox.tsx
+++ b/client/src/components/molecules/UserBox/UserBox.tsx
@@ -3,13 +3,8 @@ import styled from 'styled-components';
 import { ProfileImg } from '@components/atoms';
 import { color } from '@theme/index';
 
-interface MemberProps {
-  name: string;
-  profileUri: string;
-}
-
 interface UserBoxProps {
-  member: Array<MemberProps>;
+  member: Array<any>;
 }
 
 const UserBoxWrap = styled.div<any>`

--- a/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
+++ b/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
@@ -47,7 +47,7 @@ const ChatroomBody: React.FC<ChatroomBodyProps> = ({ title, messages, chatRoomId
     <ChatroomBodyContainter {...props}>
       <InputMessageWrap ref={MessageBodyEl}>{createMessages()}</InputMessageWrap>
       <InputBoxWrap>
-        <InputMessage title={title} chatRoomId={chatRoomId} moveScrollToTheBottom={moveScrollToTheBottom} />
+        <InputMessage title={title} chatRoomId={chatRoomId} />
       </InputBoxWrap>
     </ChatroomBodyContainter>
   );

--- a/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
+++ b/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
@@ -19,6 +19,10 @@ const ChatroomBodyContainter = styled.div<any>`
 const InputMessageWrap = styled.div<any>`
   padding-top: 1rem;
   overflow-y: scroll;
+  -ms-overflow-style: none;
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const InputBoxWrap = styled.div<any>`

--- a/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
+++ b/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
@@ -9,14 +9,19 @@ interface ChatroomBodyProps {
 }
 
 const ChatroomBodyContainter = styled.div<any>`
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  height: 100%;
-  overflow-y: scroll;
+  height: 90%;
 `;
 
 const InputMessageWrap = styled.div<any>`
+  padding-top: 1rem;
+  overflow-y: scroll;
+`;
+
+const InputBoxWrap = styled.div<any>`
   margin: 1rem;
 `;
 
@@ -29,10 +34,10 @@ const ChatroomBody: React.FC<ChatroomBodyProps> = ({ title, messages, chatRoomId
 
   return (
     <ChatroomBodyContainter {...props}>
-      <InputMessageWrap>
-        {createMessages()}
+      <InputMessageWrap>{createMessages()}</InputMessageWrap>
+      <InputBoxWrap>
         <InputMessage title={title} chatRoomId={chatRoomId} />
-      </InputMessageWrap>
+      </InputBoxWrap>
     </ChatroomBodyContainter>
   );
 };

--- a/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
+++ b/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { InputMessage, Message } from '@components/molecules';
 
@@ -26,17 +26,28 @@ const InputBoxWrap = styled.div<any>`
 `;
 
 const ChatroomBody: React.FC<ChatroomBodyProps> = ({ title, messages, chatRoomId, ...props }) => {
+  const MessageBodyEl = useRef<any>();
   const createMessages = () => {
     return messages.map((message: any) => (
       <Message key={message.messageId} author={message.user.displayName} content={message.content} src={message.user.profileUri}></Message>
     ));
   };
 
+  const moveScrollToTheBottom = () => {
+    const { scrollHeight, clientHeight } = MessageBodyEl.current;
+    const maxScrollTop = scrollHeight - clientHeight;
+    MessageBodyEl.current.scrollTop = maxScrollTop > 0 ? maxScrollTop : 0;
+  };
+
+  useEffect(() => {
+    moveScrollToTheBottom();
+  });
+
   return (
     <ChatroomBodyContainter {...props}>
-      <InputMessageWrap>{createMessages()}</InputMessageWrap>
+      <InputMessageWrap ref={MessageBodyEl}>{createMessages()}</InputMessageWrap>
       <InputBoxWrap>
-        <InputMessage title={title} chatRoomId={chatRoomId} />
+        <InputMessage title={title} chatRoomId={chatRoomId} moveScrollToTheBottom={moveScrollToTheBottom} />
       </InputBoxWrap>
     </ChatroomBodyContainter>
   );

--- a/client/src/components/organisms/ChatroomHeader/ChatroomHeader.tsx
+++ b/client/src/components/organisms/ChatroomHeader/ChatroomHeader.tsx
@@ -1,21 +1,24 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Text, Icon } from '@components/atoms';
+import { UserBox, HoverIcon } from '@components/molecules';
 import BlueStar from '@imgs/star-blue.png';
 import { color } from '@theme/index';
+import userIcon from '@imgs/user-icon.png';
+import DetailIcon from '@imgs/detail-icon.png';
 
 interface ChatroomHeaderProps {
   title: string;
+  users: Array<object>;
 }
 
 const ChatroomHeaderContainter = styled.div<any>`
-  position: fixed;
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: center;
   height: 10%;
   width: 100%;
-  border-bottom: 1px solid #e2e2e2;
+  box-shadow: 0 2px 2px -2px #e2e2e2;
   background-color: ${color.tertiary};
   z-index: 2;
 `;

--- a/client/src/components/organisms/ChatroomHeader/ChatroomHeader.tsx
+++ b/client/src/components/organisms/ChatroomHeader/ChatroomHeader.tsx
@@ -33,7 +33,15 @@ const IconWrap = styled.div<any>`
   margin-left: 0.5rem;
 `;
 
-const ChatroomHeader: React.FC<ChatroomHeaderProps> = ({ title, ...props }) => {
+const MenuContainer = styled.div<any>`
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  width: 9rem;
+  padding: 0rem 1rem;
+`;
+
+const ChatroomHeader: React.FC<ChatroomHeaderProps> = ({ title, users, ...props }) => {
   return (
     <ChatroomHeaderContainter {...props}>
       <TextContainer>
@@ -42,6 +50,11 @@ const ChatroomHeader: React.FC<ChatroomHeaderProps> = ({ title, ...props }) => {
           <Icon size="small" src={BlueStar} isHover={false} />
         </IconWrap>
       </TextContainer>
+      <MenuContainer>
+        <UserBox member={users} />
+        <HoverIcon size="medium" src={userIcon} />
+        <HoverIcon size="medium" src={DetailIcon} />
+      </MenuContainer>
     </ChatroomHeaderContainter>
   );
 };

--- a/client/src/components/organisms/ChatroomHeader/ChatroomHeader.tsx
+++ b/client/src/components/organisms/ChatroomHeader/ChatroomHeader.tsx
@@ -18,7 +18,7 @@ const ChatroomHeaderContainter = styled.div<any>`
   align-items: center;
   height: 10%;
   width: 100%;
-  box-shadow: 0 2px 2px -2px #e2e2e2;
+  box-shadow: 0 2px 2px -2px ${color.border_primary};
   background-color: ${color.tertiary};
   z-index: 2;
 `;

--- a/client/src/pages/Chatroom/Chatroom.tsx
+++ b/client/src/pages/Chatroom/Chatroom.tsx
@@ -17,7 +17,7 @@ const ChatroomContainer = styled.div<any>`
 const Chatroom: React.FC<ChatroomProps> = ({ children, ...props }) => {
   const dispatch = useDispatch();
   const { selectedChatroomId, selectedChatroom, messages } = useSelector((store: RootState) => store.chatroom);
-  const { title } = selectedChatroom;
+  const { title, users } = selectedChatroom;
 
   useEffect(() => {
     dispatch(loadAsync({ selectedChatroomId }));
@@ -28,7 +28,7 @@ const Chatroom: React.FC<ChatroomProps> = ({ children, ...props }) => {
 
   return (
     <ChatroomContainer {...props}>
-      <ChatroomHeader title={title} />
+      <ChatroomHeader title={title} users={users} />
       <ChatroomBody title={title} messages={messages} chatRoomId={selectedChatroomId} />
     </ChatroomContainer>
   );


### PR DESCRIPTION
## :bookmark_tabs: 제목

feat: chatroom 속 컴포넌트 추가

![image](https://user-images.githubusercontent.com/33643752/101594788-9c9acb00-3a35-11eb-90d5-42331c0b0eaf.png)


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] chatroomHeader border 속성 제거 후 Box-shadow 추가
- [x] ChatroomHeader UserBox 및 Icon 추가
- [x] enter키 누를 시 메시지 전송 후 값 비우기
- [x] messages의 값이 바뀔 때 scroll 제일 밑으로 이동


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Sidebar와 Chatroom의 줄 간격이 맞지 않는 부분 바꿨습니다.

