### PR TITLE
fix: 다른 채팅방에서 메시지가 오는 현상 수정 및 logout alert 삭제

### DIFF
--- a/client/src/common/store/reducers/chatroom-reducer.ts
+++ b/client/src/common/store/reducers/chatroom-reducer.ts
@@ -45,7 +45,7 @@ export default function chatroomReducer(state = initialState, action: ChatroomTy
       };
     case INSERT_MESSAGE:
       const newMessages = state.messages;
-      newMessages.push(action.payload);
+      if (action.payload.chatroomId === state.selectedChatroomId) newMessages.push(action.payload);
       return {
         ...state,
         messages: newMessages

--- a/client/src/common/store/types/chatroom-types.ts
+++ b/client/src/common/store/types/chatroom-types.ts
@@ -43,7 +43,8 @@ export interface channelState {
 }
 
 export interface messageState {
-  message: Object;
+  message: any;
+  chatroomId: number;
 }
 
 interface LoadChatroomAction {

--- a/client/src/common/utils/logout.ts
+++ b/client/src/common/utils/logout.ts
@@ -1,5 +1,4 @@
 export const logout = () => {
   window.localStorage.removeItem('token');
-  alert('토큰이 만료되어 로그아웃합니다.');
   window.location.href = '/login';
 };


### PR DESCRIPTION
## :bookmark_tabs: 제목

다른 채팅방에서 메시지가 오는 현상 수정


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 다른 채팅방에서 메시지가 오는 현상 수정
- [x] logout alert 삭제


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- API 요청에 모두 alert을 띄워줘서 일단 logout alert 삭제 했습니다.

