### PR TITLE
feat: sidebar scroll 구현

### DIFF
--- a/client/src/common/store/actions/modal-action.ts
+++ b/client/src/common/store/actions/modal-action.ts
@@ -1,4 +1,6 @@
-import { CREATE_MODAL_OPEN, CREATE_MODAL_CLOSE } from '@store/types/modal-types';
+import { CREATE_MODAL_OPEN, CREATE_MODAL_CLOSE, CHANNEL_MODAL_OPEN, CHANNEL_MODAL_CLOSE } from '@store/types/modal-types';
 
 export const createModalOpen = () => ({ type: CREATE_MODAL_OPEN });
 export const createModalClose = () => ({ type: CREATE_MODAL_CLOSE });
+export const channelModalOpen = (payload: any) => ({ type: CHANNEL_MODAL_OPEN, payload });
+export const channelModalClose = () => ({ type: CHANNEL_MODAL_CLOSE });

--- a/client/src/common/store/reducers/modal-reducer.ts
+++ b/client/src/common/store/reducers/modal-reducer.ts
@@ -1,15 +1,20 @@
-import { CreateModalState, ModalTypes, CREATE_MODAL_OPEN, CREATE_MODAL_CLOSE } from '@store/types/modal-types';
+import { ModalState, ModalTypes, CREATE_MODAL_OPEN, CREATE_MODAL_CLOSE, CHANNEL_MODAL_OPEN, CHANNEL_MODAL_CLOSE } from '@store/types/modal-types';
 
-const initialState: CreateModalState = {
-  isOpen: false
+const initialState: ModalState = {
+  createModal: { isOpen: false },
+  channelModal: { isOpen: false, x: 0, y: 0 }
 };
 
 const ModalReducer = (state = initialState, action: ModalTypes) => {
   switch (action.type) {
     case CREATE_MODAL_OPEN:
-      return { ...state, isOpen: true };
+      return { ...state, createModal: { isOpen: true }, channelModal: { isOpen: false } };
     case CREATE_MODAL_CLOSE:
-      return { ...state, isOpen: false };
+      return { ...state, createModal: { isOpen: false } };
+    case CHANNEL_MODAL_OPEN:
+      return { ...state, channelModal: { isOpen: true, x: action.payload.x, y: action.payload.y } };
+    case CHANNEL_MODAL_CLOSE:
+      return { ...state, channelModal: { isOpen: false } };
     default:
       return state;
   }

--- a/client/src/common/store/types/modal-types.ts
+++ b/client/src/common/store/types/modal-types.ts
@@ -1,18 +1,41 @@
 export const CREATE_MODAL_OPEN = 'CREATE_MODAL_OPEN';
 export const CREATE_MODAL_CLOSE = 'CREATE_MODAL_CLOSE';
+export const CHANNEL_MODAL_OPEN = 'CHANNEL_MODAL_OPEN';
+export const CHANNEL_MODAL_CLOSE = 'CHANNEL_MODAL_CLOSE';
 
-export interface CreateModalState {
+export interface CreateChannelModalState {
   isOpen: boolean;
+}
+
+export interface ChannelModalState {
+  isOpen: boolean;
+  x: number;
+  y: number;
+}
+
+export interface ModalState {
+  createModal: CreateChannelModalState;
+  channelModal: ChannelModalState;
 }
 
 interface CreateChannelModalOpenAction {
   type: typeof CREATE_MODAL_OPEN;
-  payload: CreateModalState;
+  payload: CreateChannelModalState;
 }
 
 interface CreateChannelModalCloseAction {
   type: typeof CREATE_MODAL_CLOSE;
-  payload: CreateModalState;
+  payload: CreateChannelModalState;
 }
 
-export type ModalTypes = CreateChannelModalOpenAction | CreateChannelModalCloseAction;
+interface ChannelModalOpenAction {
+  type: typeof CHANNEL_MODAL_OPEN;
+  payload: ChannelModalState;
+}
+
+interface ChannelModalCloseAction {
+  type: typeof CHANNEL_MODAL_CLOSE;
+  payload: ChannelModalState;
+}
+
+export type ModalTypes = CreateChannelModalOpenAction | CreateChannelModalCloseAction | ChannelModalOpenAction | ChannelModalCloseAction;

--- a/client/src/components/atoms/DropMenuBox/DropMenuBox.tsx
+++ b/client/src/components/atoms/DropMenuBox/DropMenuBox.tsx
@@ -1,5 +1,6 @@
 import { color } from '@theme/index';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 interface DropMenuBoxProps {
@@ -20,6 +21,8 @@ const BackgroundModal = styled.div<any>`
 
 const InnerModal = styled.div<any>`
   position: absolute;
+  top: ${(props) => `${props.y}px`};
+  left: ${(props) => `${props.x}px`};
   padding: 1rem 0rem;
   background-color: ${color.modal_bg_inner_secondary};
   z-index: 999;
@@ -29,10 +32,13 @@ const InnerModal = styled.div<any>`
 `;
 
 const DropMenuBox: React.FC<DropMenuBoxProps> = ({ children, onClick, ...props }) => {
+  const { x, y } = useSelector((store: any) => store.modal.channelModal);
   return (
     <>
       <BackgroundModal onClick={onClick} {...props}></BackgroundModal>
-      <InnerModal>{children}</InnerModal>
+      <InnerModal x={x} y={y}>
+        {children}
+      </InnerModal>
     </>
   );
 };

--- a/client/src/components/molecules/AddChannelButton/AddChannelButton.tsx
+++ b/client/src/components/molecules/AddChannelButton/AddChannelButton.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Plus from '@imgs/plus-icon.png';
-import { ChannelModal } from '@components/molecules';
 import { Icon } from '@components/atoms';
-import { DefaultSectionName } from '@constants/default-section-name';
+import { useDispatch } from 'react-redux';
+import { channelModalOpen } from '@store/actions/modal-action';
 
 interface AddChannelButtonProps {
   sectionName: string;
@@ -16,19 +16,11 @@ const IconWrap = styled.div<any>`
 `;
 
 const AddChannelButton: React.FC<AddChannelButtonProps> = ({ setHover, sectionName, ...props }) => {
-  const [isChannelModalOpened, setIsChannelModalOpened] = useState(false);
-
-  const handlingHoverIconClick = () => {
-    if (sectionName === DefaultSectionName.CHANNELS) {
-      setIsChannelModalOpened(!isChannelModalOpened);
-    }
-  };
-
-  const handlingCloseModal = () => {
-    setHover(false);
-    if (sectionName === DefaultSectionName.CHANNELS) {
-      setIsChannelModalOpened(false);
-    }
+  const dispatch = useDispatch();
+  const handlingHoverIconClick = (e: any) => {
+    const x = window.pageXOffset + e.target.getBoundingClientRect().left;
+    const y = window.pageYOffset + e.target.getBoundingClientRect().top;
+    dispatch(channelModalOpen({ x, y }));
   };
 
   return (
@@ -36,7 +28,6 @@ const AddChannelButton: React.FC<AddChannelButtonProps> = ({ setHover, sectionNa
       <IconWrap onClick={handlingHoverIconClick}>
         <Icon size="small" src={Plus} isHover={false} />
       </IconWrap>
-      {isChannelModalOpened && <ChannelModal handlingCloseModal={handlingCloseModal} />}
     </>
   );
 };

--- a/client/src/components/molecules/ChannelModal/ChannelModal.tsx
+++ b/client/src/components/molecules/ChannelModal/ChannelModal.tsx
@@ -1,27 +1,30 @@
 import React from 'react';
 import { DropMenuBox, DropMenuItem } from '@components/atoms';
-import { useDispatch } from 'react-redux';
-import { createModalOpen } from '@store/actions/modal-action';
+import { useDispatch, useSelector } from 'react-redux';
+import { createModalOpen, channelModalClose } from '@store/actions/modal-action';
 
-interface ChannelModalProps {
-  handlingCloseModal: () => void;
-}
+interface ChannelModalProps {}
 
-const ChannelModal: React.FC<ChannelModalProps> = ({ handlingCloseModal, ...props }) => {
+const ChannelModal: React.FC<ChannelModalProps> = ({ ...props }) => {
   const dispatch = useDispatch();
+  const isOpen = useSelector((store: any) => store.modal.channelModal.isOpen);
+  const handlingCloseModal = () => {
+    dispatch(channelModalClose());
+  };
   const handlingBrowseChannelsClick = () => {
-    handlingCloseModal();
+    dispatch(channelModalClose());
   };
   const handlingCreateChannelClick = () => {
     dispatch(createModalOpen());
-    handlingCloseModal();
   };
   return (
     <>
-      <DropMenuBox onClick={() => handlingCloseModal()} {...props}>
-        <DropMenuItem onClick={handlingBrowseChannelsClick}> Browse channels </DropMenuItem>
-        <DropMenuItem onClick={handlingCreateChannelClick}> Create a channel </DropMenuItem>
-      </DropMenuBox>
+      {isOpen ? (
+        <DropMenuBox onClick={() => handlingCloseModal()} {...props}>
+          <DropMenuItem onClick={handlingBrowseChannelsClick}> Browse channels </DropMenuItem>
+          <DropMenuItem onClick={handlingCreateChannelClick}> Create a channel </DropMenuItem>
+        </DropMenuBox>
+      ) : null}
     </>
   );
 };

--- a/client/src/components/organisms/CreateChannelModal/CreateChannelModal.tsx
+++ b/client/src/components/organisms/CreateChannelModal/CreateChannelModal.tsx
@@ -38,7 +38,7 @@ const SubmitButtonCantainer = styled.div`
 
 const CreateChannelModal: React.FC<CreateChannelModalProps> = ({ ...props }) => {
   const dispatch = useDispatch();
-  const isOpen = useSelector((store: any) => store.modal.isOpen);
+  const isOpen = useSelector((store: any) => store.modal.createModal.isOpen);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [isPrivate, setIsPrivate] = useState(false);

--- a/client/src/components/organisms/Sidebar/Sidebar.tsx
+++ b/client/src/components/organisms/Sidebar/Sidebar.tsx
@@ -23,11 +23,21 @@ const Workspace = styled.div<any>`
   align-items: center;
   height: 10%;
   padding-left: 1rem;
-  border-bottom: 1px solid ${color.sidebar_border};
+  box-shadow: 0 1.5px 2px -2px ${color.border_primary};
 `;
 
 const ChildrenWrap = styled.div<any>`
-  padding: 1rem;
+  overflow-y: scroll;
+  padding: 0rem 1rem;
+  height: 90%;
+  -ms-overflow-style: none;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const SectionWrap = styled.div<any>`
+  padding: 1rem 0rem;
 `;
 
 const Sidebar: React.FC<SidebarProps> = ({ children, ...props }) => {
@@ -71,9 +81,11 @@ const Sidebar: React.FC<SidebarProps> = ({ children, ...props }) => {
         </Text>
       </Workspace>
       <ChildrenWrap>
-        {createSection(starred, DefaultSectionName.STARRED)}
-        {createSection(channels, DefaultSectionName.CHANNELS)}
-        {createSection(directMessages, DefaultSectionName.DIRECT_MESSAGES)}
+        <SectionWrap>
+          {createSection(starred, DefaultSectionName.STARRED)}
+          {createSection(channels, DefaultSectionName.CHANNELS)}
+          {createSection(directMessages, DefaultSectionName.DIRECT_MESSAGES)}
+        </SectionWrap>
       </ChildrenWrap>
     </StyledSidebar>
   );

--- a/client/src/components/templates/Body.tsx
+++ b/client/src/components/templates/Body.tsx
@@ -1,0 +1,20 @@
+import { channelModalClose } from '@store/actions/modal-action';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import styled from 'styled-components';
+
+const StyledBody = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const Body: React.FC<any> = ({ children }) => {
+  const dispatch = useDispatch();
+  const handlingLeave = () => {
+    dispatch(channelModalClose());
+  };
+  return <StyledBody onMouseLeave={handlingLeave}>{children}</StyledBody>;
+};
+
+export default Body;

--- a/client/src/components/templates/index.ts
+++ b/client/src/components/templates/index.ts
@@ -1,5 +1,6 @@
 import FlexContainer from './FlexContainer';
 import Main from './Main';
 import MainBox from './MainBox';
+import Body from './Body';
 
-export { FlexContainer, Main, MainBox };
+export { FlexContainer, Main, MainBox, Body };

--- a/client/src/shared/App.tsx
+++ b/client/src/shared/App.tsx
@@ -3,7 +3,8 @@ import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import { Chatroom, Login } from '@pages/index';
 import { Header, Sidebar, CreateChannelModal } from '@components/organisms';
 import { registerToken, blockPage } from '@utils/index';
-import { Main, MainBox } from '@components/templates';
+import { Main, MainBox, Body } from '@components/templates';
+import { ChannelModal } from '@components/molecules';
 
 const App = () => {
   useEffect(() => {
@@ -17,15 +18,18 @@ const App = () => {
       <Switch>
         <Route exact path="/login" component={Login} />
         <Fragment>
-          <Header />
-          <Main>
-            <Sidebar />
-            <MainBox>
-              <Route exact path="/" />
-              <Route exact path="/client/:id" component={Chatroom} />
-            </MainBox>
-          </Main>
-          <CreateChannelModal />
+          <Body>
+            <Header />
+            <Main>
+              <Sidebar />
+              <MainBox>
+                <Route exact path="/" />
+                <Route exact path="/client/:id" component={Chatroom} />
+              </MainBox>
+            </Main>
+            <CreateChannelModal />
+            <ChannelModal />
+          </Body>
         </Fragment>
       </Switch>
     </BrowserRouter>


### PR DESCRIPTION
## :bookmark_tabs: 제목

sidebar scroll 구현


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] sidebar scroll 구현
- [x] channelModal 숨겨지는 에러 해결


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- scroll 속성으로 바꾸면서 모달이 숨겨지는 현상이 발생했었습니다. 그래서 sidebar에서가 아닌 app에서 관리를 해주기로 했습니다.
- ```+``` 버튼을 클릭했을 때 모달창에 대한 정보는 store로 관리합니다.
- 모달창이 켜져있을 때 브라우저를 조절하지 못하게 Body 컴포넌트를 벗어나면 모달을 껐습니다.
