### PR TITLE
feat: Browse Page 라우팅 및 화면 구성

### DIFF
--- a/client/src/common/store/actions/chatroom-action.ts
+++ b/client/src/common/store/actions/chatroom-action.ts
@@ -1,7 +1,15 @@
-import { LOAD_ASYNC, INIT_SIDEBAR_ASYNC, PICK_CHANNEL_ASYNC, INSERT_MESSAGE, ADD_CHANNEL_ASYNC } from '../types/chatroom-types';
+import {
+  LOAD_ASYNC,
+  INIT_SIDEBAR_ASYNC,
+  PICK_CHANNEL_ASYNC,
+  INSERT_MESSAGE,
+  ADD_CHANNEL_ASYNC,
+  RESET_SELECTED_CHANNEL
+} from '../types/chatroom-types';
 
 export const loadAsync = (payload: any) => ({ type: LOAD_ASYNC, payload });
 export const initSidebarAsync = () => ({ type: INIT_SIDEBAR_ASYNC });
 export const pickChannel = (payload: any) => ({ type: PICK_CHANNEL_ASYNC, payload });
 export const insertMessage = (payload: any) => ({ type: INSERT_MESSAGE, payload });
 export const addChannel = (payload: any) => ({ type: ADD_CHANNEL_ASYNC, payload });
+export const resetSelectedChannel = () => ({ type: RESET_SELECTED_CHANNEL });

--- a/client/src/common/store/reducers/chatroom-reducer.ts
+++ b/client/src/common/store/reducers/chatroom-reducer.ts
@@ -1,6 +1,15 @@
 /* eslint-disable no-case-declarations */
 import { uriParser } from '@utils/index';
-import { chatroomState, LOAD, ChatroomTypes, PICK_CHANNEL, INIT_SIDEBAR, INSERT_MESSAGE, ADD_CHANNEL } from '../types/chatroom-types';
+import {
+  chatroomState,
+  LOAD,
+  ChatroomTypes,
+  PICK_CHANNEL,
+  INIT_SIDEBAR,
+  INSERT_MESSAGE,
+  ADD_CHANNEL,
+  RESET_SELECTED_CHANNEL
+} from '../types/chatroom-types';
 
 const initialState: chatroomState = {
   selectedChatroom: {
@@ -56,6 +65,22 @@ export default function chatroomReducer(state = initialState, action: ChatroomTy
       return {
         ...state,
         channels: newChannels
+      };
+    case RESET_SELECTED_CHANNEL:
+      const selectedChatroom = {
+        chatType: '',
+        description: '',
+        isPrivate: false,
+        title: '',
+        topic: '',
+        userCount: 0,
+        users: []
+      };
+      return {
+        ...state,
+        selectedChatroom,
+        selectedChatroomId: null,
+        messages: []
       };
     default:
       return state;

--- a/client/src/common/store/types/chatroom-types.ts
+++ b/client/src/common/store/types/chatroom-types.ts
@@ -7,6 +7,7 @@ export const PICK_CHANNEL_ASYNC = 'PICK_CHANNEL_ASYNC';
 export const INSERT_MESSAGE = 'INSERT_MESSAGE';
 export const ADD_CHANNEL = 'ADD_CHANNEL';
 export const ADD_CHANNEL_ASYNC = 'ADD_CHANNEL_ASYNC';
+export const RESET_SELECTED_CHANNEL = 'RESET_SELECTED_CHANNEL';
 
 export interface selectedChatroomState {
   chatType: string;
@@ -72,4 +73,14 @@ interface AddChannelAction {
   payload: selectedChatroomState;
 }
 
-export type ChatroomTypes = LoadChatroomAction | InitSidebarAction | PickChannelAction | InsertMessageAction | AddChannelAction;
+interface ResetSelectedChannel {
+  type: typeof RESET_SELECTED_CHANNEL;
+}
+
+export type ChatroomTypes =
+  | LoadChatroomAction
+  | InitSidebarAction
+  | PickChannelAction
+  | InsertMessageAction
+  | AddChannelAction
+  | ResetSelectedChannel;

--- a/client/src/components/molecules/BrowsePageControls/BrowsePageControls.stories.tsx
+++ b/client/src/components/molecules/BrowsePageControls/BrowsePageControls.stories.tsx
@@ -7,14 +7,9 @@ export default {
   component: BrowsePageControls
 } as Meta;
 
-const handlingSortButton = () => {};
-const handlingFilterButton = () => {};
-
 const Template: Story<BrowsePageControlsProps> = (args) => <BrowsePageControls {...args} />;
 
 export const BlackBrowsePageControls = Template.bind({});
 BlackBrowsePageControls.args = {
-  channelCount: 193,
-  handlingSortButton,
-  handlingFilterButton
+  channelCount: 193
 };

--- a/client/src/components/molecules/BrowsePageControls/BrowsePageControls.tsx
+++ b/client/src/components/molecules/BrowsePageControls/BrowsePageControls.tsx
@@ -8,8 +8,6 @@ import FilterIcon from '@imgs/filter-icon.png';
 
 interface BrowsePageControlsProps {
   channelCount: number;
-  handlingSortButton?: () => void;
-  handlingFilterButton?: () => void;
 }
 
 export const SortMethods = {
@@ -33,8 +31,11 @@ const BrowsePageControlsButtonWrap = styled.div<any>`
   display: flex;
 `;
 
-const BrowsePageControls: React.FC<BrowsePageControlsProps> = ({ channelCount, handlingSortButton, handlingFilterButton, ...props }) => {
+const BrowsePageControls: React.FC<BrowsePageControlsProps> = ({ channelCount, ...props }) => {
   const [sortMethod, setSortMethod] = useState<SortMethod>(SortMethods.A_TO_Z);
+
+  const handlingSortButton = () => {};
+  const handlingFilterButton = () => {};
 
   return (
     <BrowsePageControlsWrap {...props}>

--- a/client/src/components/molecules/BrowsePageControls/BrowsePageControls.tsx
+++ b/client/src/components/molecules/BrowsePageControls/BrowsePageControls.tsx
@@ -8,8 +8,8 @@ import FilterIcon from '@imgs/filter-icon.png';
 
 interface BrowsePageControlsProps {
   channelCount: number;
-  handlingSortButton: () => void;
-  handlingFilterButton: () => void;
+  handlingSortButton?: () => void;
+  handlingFilterButton?: () => void;
 }
 
 export const SortMethods = {
@@ -26,7 +26,7 @@ const BrowsePageControlsWrap = styled.div<any>`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 1rem;
+  padding: 0.4rem 1.5rem;
 `;
 
 const BrowsePageControlsButtonWrap = styled.div<any>`
@@ -38,7 +38,7 @@ const BrowsePageControls: React.FC<BrowsePageControlsProps> = ({ channelCount, h
 
   return (
     <BrowsePageControlsWrap {...props}>
-      <Text fontColor={color.primary} size="small" isBold={true}>
+      <Text fontColor={color.primary} size="superSmall">
         {`${channelCount} channels`}
       </Text>
       <BrowsePageControlsButtonWrap>

--- a/client/src/components/molecules/BrowsePageSearchBar/BrowsePageSearchBar.tsx
+++ b/client/src/components/molecules/BrowsePageSearchBar/BrowsePageSearchBar.tsx
@@ -20,7 +20,7 @@ const StyledInput = styled.input<any>`
   border: 0 none;
   outline: none;
   width: fill-available;
-  font-size: 1rem;
+  font-size: 0.8rem;
 `;
 
 const InputHintWrap = styled.div<any>`

--- a/client/src/components/molecules/ChannelModal/ChannelModal.tsx
+++ b/client/src/components/molecules/ChannelModal/ChannelModal.tsx
@@ -1,17 +1,25 @@
 import React from 'react';
 import { DropMenuBox, DropMenuItem } from '@components/atoms';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { createModalOpen, channelModalClose } from '@store/actions/modal-action';
+import { resetSelectedChannel } from '@store/actions/chatroom-action';
 
 interface ChannelModalProps {}
 
 const ChannelModal: React.FC<ChannelModalProps> = ({ ...props }) => {
+  const history = useHistory();
   const dispatch = useDispatch();
+
   const isOpen = useSelector((store: any) => store.modal.channelModal.isOpen);
+
   const handlingCloseModal = () => {
     dispatch(channelModalClose());
   };
   const handlingBrowseChannelsClick = () => {
+    if (window.location.pathname !== `/channel-browser`) history.push(`/channel-browser`);
+    dispatch(resetSelectedChannel());
+
     dispatch(channelModalClose());
   };
   const handlingCreateChannelClick = () => {

--- a/client/src/components/molecules/index.ts
+++ b/client/src/components/molecules/index.ts
@@ -18,6 +18,7 @@ import { WhiteButtonWithIcon } from './WhiteButtonWithIcon/WhiteButtonWithIcon';
 import { HoverIcon } from './HoverIcon/HoverIcon';
 import { Actionbar } from './Actionbar/Actionbar';
 import { AddChannelButton } from './AddChannelButton/AddChannelButton';
+import { BrowsePageSearchBar } from './BrowsePageSearchBar/BrowsePageSearchBar';
 
 export {
   Actionbar,
@@ -39,5 +40,6 @@ export {
   ChannelModal,
   AddChannelButton,
   BrowsePageControls,
-  WhiteButtonWithIcon
+  WhiteButtonWithIcon,
+  BrowsePageSearchBar
 };

--- a/client/src/components/organisms/BrowsePageChannel/BrowsePageChannel.tsx
+++ b/client/src/components/organisms/BrowsePageChannel/BrowsePageChannel.tsx
@@ -36,6 +36,7 @@ const BrowsePageChannelContent = styled.div<any>`
 
 const ButtonWrap = styled.div<any>`
   display: flex;
+  margin-right: 0.5rem;
   button {
     display: none;
   }

--- a/client/src/components/organisms/BrowsePageHeader/BrowsePageHeader.tsx
+++ b/client/src/components/organisms/BrowsePageHeader/BrowsePageHeader.tsx
@@ -21,7 +21,7 @@ const BrowsePageHeaderWrap = styled.div<any>`
 const ContentWrap = styled.div<any>`
   display: flex;
   align-items: center;
-  padding: 0rem 1rem;
+  padding: 0rem 1.6rem;
 `;
 
 const BrowsePageHeader: React.FC<BrowsePageHeaderProps> = ({ onClick, ...props }) => {

--- a/client/src/components/organisms/BrowsePageHeader/BrowsePageHeader.tsx
+++ b/client/src/components/organisms/BrowsePageHeader/BrowsePageHeader.tsx
@@ -4,7 +4,7 @@ import { Text, Button } from '@components/atoms';
 import { color } from '@theme/index';
 
 interface BrowsePageHeaderProps {
-  onClick: () => void;
+  onClick?: () => void;
 }
 
 const BrowsePageHeaderWrap = styled.div<any>`

--- a/client/src/components/organisms/index.ts
+++ b/client/src/components/organisms/index.ts
@@ -5,5 +5,6 @@ import { ChatroomBody } from './ChatroomBody/ChatroomBody';
 import { LoginForm } from './LoginForm/LoginForm';
 import { BrowsePageChannel } from './BrowsePageChannel/BrowsePageChannel';
 import { CreateChannelModal } from './CreateChannelModal/CreateChannelModal';
+import { BrowsePageHeader } from './BrowsePageHeader/BrowsePageHeader';
 
-export { Header, Sidebar, ChatroomHeader, ChatroomBody, LoginForm, BrowsePageChannel, CreateChannelModal };
+export { Header, Sidebar, ChatroomHeader, ChatroomBody, LoginForm, BrowsePageChannel, CreateChannelModal, BrowsePageHeader };

--- a/client/src/components/templates/Body.tsx
+++ b/client/src/components/templates/Body.tsx
@@ -1,7 +1,9 @@
-import { channelModalClose } from '@store/actions/modal-action';
-import React from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
+import { channelModalClose } from '@store/actions/modal-action';
+import { useDispatch } from 'react-redux';
+import { insertMessage } from '@store/actions/chatroom-action';
+import socket from '@socket/socketIO';
 
 const StyledBody = styled.div`
   position: relative;
@@ -11,6 +13,11 @@ const StyledBody = styled.div`
 
 const Body: React.FC<any> = ({ children }) => {
   const dispatch = useDispatch();
+  useEffect(() => {
+    socket.on('create message', (message: any) => {
+      dispatch(insertMessage(message));
+    });
+  }, []);
   const handlingLeave = () => {
     dispatch(channelModalClose());
   };

--- a/client/src/pages/ChannelBrowser/ChannelBrowser.tsx
+++ b/client/src/pages/ChannelBrowser/ChannelBrowser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { BrowsePageHeader, BrowsePageChannel } from '@components/organisms';
-import { BrowsePageControls, BrowsePageSearchBar } from '@components/molecules';
+import { BrowsePageHeader } from '@components/organisms';
+import { BrowsePageSearchBar } from '@components/molecules';
 
 interface ChannelBrowserProps {
   children: React.ReactNode;
@@ -22,8 +22,6 @@ const ChannelBrowser: React.FC<ChannelBrowserProps> = ({ children, ...props }) =
       <SearchBarWrap>
         <BrowsePageSearchBar />
       </SearchBarWrap>
-      <BrowsePageControls channelCount={1} />
-      <BrowsePageChannel name="notice" isJoined={true} memberCount={4} description={'공지사항을 안내하는 채널'} isPrivate={true} />
     </ChannelBrowserContainer>
   );
 };

--- a/client/src/pages/ChannelBrowser/ChannelBrowser.tsx
+++ b/client/src/pages/ChannelBrowser/ChannelBrowser.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { BrowsePageHeader } from '@components/organisms';
+import { BrowsePageHeader, BrowsePageChannel } from '@components/organisms';
+import { BrowsePageControls, BrowsePageSearchBar } from '@components/molecules';
 
 interface ChannelBrowserProps {
   children: React.ReactNode;
@@ -10,10 +11,19 @@ const ChannelBrowserContainer = styled.div<any>`
   height: 100%;
 `;
 
+const SearchBarWrap = styled.div<any>`
+  padding: 1rem 1.5rem;
+`;
+
 const ChannelBrowser: React.FC<ChannelBrowserProps> = ({ children, ...props }) => {
   return (
     <ChannelBrowserContainer {...props}>
       <BrowsePageHeader />
+      <SearchBarWrap>
+        <BrowsePageSearchBar />
+      </SearchBarWrap>
+      <BrowsePageControls channelCount={1} />
+      <BrowsePageChannel name="notice" isJoined={true} memberCount={4} description={'공지사항을 안내하는 채널'} isPrivate={true} />
     </ChannelBrowserContainer>
   );
 };

--- a/client/src/pages/ChannelBrowser/ChannelBrowser.tsx
+++ b/client/src/pages/ChannelBrowser/ChannelBrowser.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+import { BrowsePageHeader } from '@components/organisms';
+
+interface ChannelBrowserProps {
+  children: React.ReactNode;
+}
+
+const ChannelBrowserContainer = styled.div<any>`
+  height: 100%;
+`;
+
+const ChannelBrowser: React.FC<ChannelBrowserProps> = ({ children, ...props }) => {
+  return (
+    <ChannelBrowserContainer {...props}>
+      <BrowsePageHeader />
+    </ChannelBrowserContainer>
+  );
+};
+
+export { ChannelBrowser };

--- a/client/src/pages/Chatroom/Chatroom.tsx
+++ b/client/src/pages/Chatroom/Chatroom.tsx
@@ -3,8 +3,7 @@ import styled from 'styled-components';
 import { ChatroomHeader, ChatroomBody } from '@components/organisms';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@store/reducers/index';
-import { insertMessage, loadAsync } from '@store/actions/chatroom-action';
-import socket from '@socket/socketIO';
+import { loadAsync } from '@store/actions/chatroom-action';
 
 interface ChatroomProps {
   children: React.ReactNode;
@@ -18,12 +17,8 @@ const Chatroom: React.FC<ChatroomProps> = ({ children, ...props }) => {
   const dispatch = useDispatch();
   const { selectedChatroomId, selectedChatroom, messages } = useSelector((store: RootState) => store.chatroom);
   const { title, users } = selectedChatroom;
-
   useEffect(() => {
     dispatch(loadAsync({ selectedChatroomId }));
-    socket.on('create message', (message: any) => {
-      dispatch(insertMessage(message));
-    });
   }, []);
 
   return (

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -1,4 +1,5 @@
 import { Chatroom } from './Chatroom/Chatroom';
 import { Login } from './Login';
+import { ChannelBrowser } from './ChannelBrowser/ChannelBrowser';
 
-export { Chatroom, Login };
+export { Chatroom, Login, ChannelBrowser };

--- a/client/src/shared/App.tsx
+++ b/client/src/shared/App.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect } from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
-import { Chatroom, Login } from '@pages/index';
+import { Chatroom, Login, ChannelBrowser } from '@pages/index';
 import { Header, Sidebar, CreateChannelModal } from '@components/organisms';
 import { registerToken, blockPage } from '@utils/index';
 import { Main, MainBox, Body } from '@components/templates';
@@ -25,6 +25,7 @@ const App = () => {
               <MainBox>
                 <Route exact path="/" />
                 <Route exact path="/client/:id" component={Chatroom} />
+                <Route exact path="/channel-browser" component={ChannelBrowser} />
               </MainBox>
             </Main>
             <CreateChannelModal />


### PR DESCRIPTION
## :bookmark_tabs: 제목

Browse Page 라우팅 및 화면 구성

resolved: #161 

![image](https://user-images.githubusercontent.com/59037261/101801868-2770e800-3b52-11eb-96ed-2a444e201e0f.png)


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Browse Page 생성
- [x] Browse Page 라우터 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Browse Page로 이동할 경우 선택된 채팅방 상태를 초기화하기 위해 Chatroom Store에 resetSelectedChannel을 추가했습니다.
