### PR TITLE
feat: 전체 chatroom 조회에 isJoined 프로퍼티, 헤더에 채널 전체 갯수 추가 구현

### DIFF
--- a/server/src/controller/chatroom-controller.ts
+++ b/server/src/controller/chatroom-controller.ts
@@ -28,6 +28,8 @@ const ChatroomController = {
       const { userId } = req.user;
       const { offsetTitle } = req.query;
       const chatrooms = await ChatroomService.getInstance().getChatrooms(Number(userId), String(offsetTitle));
+      const chatroomCount = await ChatroomService.getInstance().getChatroomCount(userId);
+      res.setHeader('X-total-count', chatroomCount);
       res.status(HttpStatusCode.OK).json(chatrooms);
     } catch (err) {
       next(err);

--- a/server/src/controller/chatroom-controller.ts
+++ b/server/src/controller/chatroom-controller.ts
@@ -27,7 +27,7 @@ const ChatroomController = {
     try {
       const { userId } = req.user;
       const { offsetTitle } = req.query;
-      const chatrooms = await ChatroomService.getInstance().getChatrooms(Number(userId), Number(offsetTitle));
+      const chatrooms = await ChatroomService.getInstance().getChatrooms(Number(userId), String(offsetTitle));
       res.status(HttpStatusCode.OK).json(chatrooms);
     } catch (err) {
       next(err);

--- a/server/src/service/chatroom-service.ts
+++ b/server/src/service/chatroom-service.ts
@@ -219,7 +219,7 @@ class ChatroomService {
   async getChatroomCount(userId: number) {
     const chatrooms = await this.chatroomRepository
       .createQueryBuilder('chatroom')
-      .where('chatroom.chatType = :chatType', { chatType: 'Channel' })
+      .where('chatroom.chatType = :chatType', { chatType: ChatType.Channel })
       .leftJoin('chatroom.userChatrooms', 'userChatrooms')
       .leftJoin('userChatrooms.user', 'user')
       .select(['chatroom.chatroomId', 'chatroom.title', 'chatroom.description', 'chatroom.isPrivate'])

--- a/server/src/service/chatroom-service.ts
+++ b/server/src/service/chatroom-service.ts
@@ -9,6 +9,7 @@ import NotFoundError from '@error/not-found-error';
 import ChatType from '@constants/chat-type';
 import DefaultSectionName from '@constants/default-section-name';
 import ConflictError from '@error/conflict-error';
+import UserChatroom from '@model/user-chatroom';
 
 class ChatroomService {
   static instance: ChatroomService;
@@ -108,9 +109,9 @@ class ChatroomService {
     return newUserChatroom;
   }
 
-  async getChatrooms(userId: Number, offsetTitle) {
+  async getChatrooms(userId: Number, offsetTitle: String) {
     let where = 'chatroom.chatType = :chatType';
-    if (offsetTitle) where += ' AND chatroom.title > :offsetTitle';
+    if (offsetTitle !== 'undefined') where += ' AND chatroom.title > :offsetTitle';
     const chatrooms = await this.chatroomRepository
       .createQueryBuilder('chatroom')
       .where(where, { chatType: 'Channel', offsetTitle })
@@ -121,27 +122,30 @@ class ChatroomService {
       .addSelect(['user.userId'])
       .orderBy('chatroom.title')
       .getMany();
-    const filterChatrooms = this.getFilterPrivateChatrooms(chatrooms, userId);
-    const customChatrooms = this.getCustomChatrooms(filterChatrooms);
+    const { filterChatrooms, isJoinedArr } = this.getFilterPrivateChatrooms(chatrooms, userId);
+    const customChatrooms = this.getCustomChatrooms(filterChatrooms, isJoinedArr);
     return customChatrooms.slice(0, 20);
   }
 
   private getFilterPrivateChatrooms(chatrooms: any, userId: Number) {
-    return chatrooms.filter((chatroom) => {
-      let isJoin;
-      if (chatroom.isPrivate)
-        chatroom.userChatrooms.forEach((userChatroom) => {
-          if (userChatroom.user.userId === userId) isJoin = true;
-        });
-      return !chatroom.isPrivate || isJoin;
+    let isJoinedArr = [];
+    const filterChatrooms = chatrooms.filter((chatroom) => {
+      let isJoined = false;
+      chatroom.userChatrooms.forEach((userChatroom) => {
+        if (userChatroom.user.userId === userId) isJoined = true;
+      });
+      if (isJoined || !chatroom.isPrivate) isJoinedArr.push(isJoined);
+      return !chatroom.isPrivate || isJoined;
     });
+    return { filterChatrooms, isJoinedArr };
   }
 
-  private getCustomChatrooms(chatrooms: any) {
-    return chatrooms.map((chatroom) => {
+  private getCustomChatrooms(chatrooms: any, isJoinedArr: any) {
+    return chatrooms.map((chatroom, idx) => {
       const { chatroomId, title, description, isPrivate, userChatrooms } = chatroom;
       const members = userChatrooms.length;
-      return { chatroomId, title, description, isPrivate, members };
+      const isJoinend = isJoinedArr[idx];
+      return { chatroomId, title, description, isPrivate, members, isJoinend };
     });
   }
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

feat: 전체 chatroom 조회에 isJoined 프로퍼티, 헤더에 채널 전체 갯수 추가 구현

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] chatroom에 isjoined 프로퍼티 추가
- [x] chatroom 조회시 헤더(```X-total-count```)에 전체 chatroom 개수 추가
- [x] chatroom 관련 string이 아닌 number로 넘어가서 조회가 정상적으로 안되던 버그 수정


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

![image](https://user-images.githubusercontent.com/37091190/101855049-25387900-3ba6-11eb-848a-e85c0249f67c.png)

![image](https://user-images.githubusercontent.com/37091190/101854997-09cd6e00-3ba6-11eb-9b6a-7dd1066a0235.png)


