### PR TITLE
feat: Browse Page 채널 목록 구현

### DIFF
--- a/client/src/components/molecules/BrowsePageChannelBody/BrowsePageChannelBody.stories.tsx
+++ b/client/src/components/molecules/BrowsePageChannelBody/BrowsePageChannelBody.stories.tsx
@@ -12,6 +12,6 @@ const Template: Story<BrowsePageChannelBodyProps> = (args) => <BrowsePageChannel
 export const BlackBrowsePageChannelBody = Template.bind({});
 BlackBrowsePageChannelBody.args = {
   isJoined: true,
-  memberCount: 4,
+  members: 4,
   description: '공지사항을 안내하는 채널'
 };

--- a/client/src/components/molecules/BrowsePageChannelBody/BrowsePageChannelBody.tsx
+++ b/client/src/components/molecules/BrowsePageChannelBody/BrowsePageChannelBody.tsx
@@ -5,7 +5,7 @@ import { color } from '@theme/index';
 
 interface BrowsePageChannelBodyProps {
   isJoined?: boolean;
-  memberCount: number;
+  members: number;
   description?: string;
 }
 
@@ -16,7 +16,7 @@ const BrowsePageChannelBodyWrap = styled.div<any>`
   }
 `;
 
-const BrowsePageChannelBody: React.FC<BrowsePageChannelBodyProps> = ({ isJoined, memberCount, description, ...props }) => {
+const BrowsePageChannelBody: React.FC<BrowsePageChannelBodyProps> = ({ isJoined, members, description, ...props }) => {
   return (
     <BrowsePageChannelBodyWrap {...props}>
       {isJoined && (
@@ -25,7 +25,7 @@ const BrowsePageChannelBody: React.FC<BrowsePageChannelBodyProps> = ({ isJoined,
         </Text>
       )}
       <Text fontColor={color.text_tertiary} size="superSmall">
-        {`${memberCount} members`}
+        {`${members} members`}
       </Text>
       {description && (
         <Text fontColor={color.text_tertiary} size="superSmall">

--- a/client/src/components/molecules/BrowsePageChannelHeader/BrowsePageChannelHeader.stories.tsx
+++ b/client/src/components/molecules/BrowsePageChannelHeader/BrowsePageChannelHeader.stories.tsx
@@ -11,6 +11,6 @@ const Template: Story<BrowsePageChannelHeaderProps> = (args) => <BrowsePageChann
 
 export const BlackBrowsePageChannelHeader = Template.bind({});
 BlackBrowsePageChannelHeader.args = {
-  name: 'notice',
+  title: 'notice',
   isPrivate: true
 };

--- a/client/src/components/molecules/BrowsePageChannelHeader/BrowsePageChannelHeader.tsx
+++ b/client/src/components/molecules/BrowsePageChannelHeader/BrowsePageChannelHeader.tsx
@@ -6,7 +6,7 @@ import LockIcon from '@imgs/lock-icon.png';
 import { color } from '@theme/index';
 
 interface BrowsePageChannelHeaderProps {
-  name: string;
+  title: string;
   isPrivate?: boolean;
 }
 
@@ -17,12 +17,12 @@ const BrowsePageChannelHeaderWrap = styled.div<any>`
   }
 `;
 
-const BrowsePageChannelHeader: React.FC<BrowsePageChannelHeaderProps> = ({ name, isPrivate, ...props }) => {
+const BrowsePageChannelHeader: React.FC<BrowsePageChannelHeaderProps> = ({ title, isPrivate, ...props }) => {
   return (
     <BrowsePageChannelHeaderWrap {...props}>
       <Icon size="small" src={isPrivate ? LockIcon : ChannelIcon} isHover={false} />
       <Text fontColor={color.primary} size="small" isBold={true}>
-        {name}
+        {title}
       </Text>
     </BrowsePageChannelHeaderWrap>
   );

--- a/client/src/components/molecules/BrowsePageControls/BrowsePageControls.tsx
+++ b/client/src/components/molecules/BrowsePageControls/BrowsePageControls.tsx
@@ -24,7 +24,10 @@ const BrowsePageControlsWrap = styled.div<any>`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.4rem 1.5rem;
+  padding-top: 0.4rem;
+  padding-bottom: 1rem;
+  margin-left: 1.5rem;
+  margin-right: 2.5rem;
   border-bottom: 0.5px solid ${color.border_secondary};
 `;
 

--- a/client/src/components/molecules/BrowsePageControls/BrowsePageControls.tsx
+++ b/client/src/components/molecules/BrowsePageControls/BrowsePageControls.tsx
@@ -25,6 +25,7 @@ const BrowsePageControlsWrap = styled.div<any>`
   justify-content: space-between;
   align-items: center;
   padding: 0.4rem 1.5rem;
+  border-bottom: 0.5px solid ${color.border_secondary};
 `;
 
 const BrowsePageControlsButtonWrap = styled.div<any>`

--- a/client/src/components/molecules/BrowsePageSearchBar/BrowsePageSearchBar.tsx
+++ b/client/src/components/molecules/BrowsePageSearchBar/BrowsePageSearchBar.tsx
@@ -20,7 +20,7 @@ const StyledInput = styled.input<any>`
   border: 0 none;
   outline: none;
   width: fill-available;
-  font-size: 0.8rem;
+  font-size: 0.9rem;
 `;
 
 const InputHintWrap = styled.div<any>`

--- a/client/src/components/organisms/BrowsePageChannel/BrowsePageChannel.stories.tsx
+++ b/client/src/components/organisms/BrowsePageChannel/BrowsePageChannel.stories.tsx
@@ -14,9 +14,9 @@ const handlingLeaveButton = () => {};
 
 export const BlackBrowsePageChannel = Template.bind({});
 BlackBrowsePageChannel.args = {
-  name: 'notice',
+  title: 'notice',
   isJoined: true,
-  memberCount: 4,
+  members: 4,
   description: '공지사항을 안내하는 채널',
   isPrivate: true,
   handlingJoinButton,

--- a/client/src/components/organisms/BrowsePageChannel/BrowsePageChannel.tsx
+++ b/client/src/components/organisms/BrowsePageChannel/BrowsePageChannel.tsx
@@ -6,11 +6,11 @@ import { BrowsePageChannelBody } from '@components/molecules/BrowsePageChannelBo
 import { BrowsePageChannelButton } from '@components/molecules/BrowsePageChannelButton/BrowsePageChannelButton';
 
 interface BrowsePageChannelProps {
-  name: string;
-  isJoined?: boolean;
-  memberCount: number;
+  title: string;
   description?: string;
   isPrivate?: boolean;
+  members: number;
+  isJoined?: boolean;
   handlingJoinButton?: () => void;
   handlingLeaveButton?: () => void;
 }
@@ -19,6 +19,7 @@ const BrowsePageChannelContainer = styled.div<any>`
   display: flex;
   justify-content: space-between;
   padding: 1rem 1rem;
+  border-bottom: 1px solid ${color.border_secondary};
   &:hover {
     background-color: ${color.hover_primary};
     button {
@@ -43,9 +44,9 @@ const ButtonWrap = styled.div<any>`
 `;
 
 const BrowsePageChannel: React.FC<BrowsePageChannelProps> = ({
-  name,
+  title,
   isJoined,
-  memberCount,
+  members,
   description,
   isPrivate,
   handlingJoinButton,
@@ -55,8 +56,8 @@ const BrowsePageChannel: React.FC<BrowsePageChannelProps> = ({
   return (
     <BrowsePageChannelContainer {...props}>
       <BrowsePageChannelContent>
-        <BrowsePageChannelHeader name={name} isPrivate={isPrivate} {...props}></BrowsePageChannelHeader>
-        <BrowsePageChannelBody isJoined={isJoined} memberCount={memberCount} description={description} {...props}></BrowsePageChannelBody>
+        <BrowsePageChannelHeader title={title} isPrivate={isPrivate} {...props}></BrowsePageChannelHeader>
+        <BrowsePageChannelBody isJoined={isJoined} members={members} description={description} {...props}></BrowsePageChannelBody>
       </BrowsePageChannelContent>
       <ButtonWrap>
         <BrowsePageChannelButton

--- a/client/src/components/organisms/BrowsePageChannelList/BrowsePageChannelList.stories.tsx
+++ b/client/src/components/organisms/BrowsePageChannelList/BrowsePageChannelList.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { BrowsePageChannelList, BrowsePageChannelListProps } from './BrowsePageChannelList';
+
+export default {
+  title: 'organisms/BrowsePageChannelList',
+  component: BrowsePageChannelList
+} as Meta;
+
+const Template: Story<BrowsePageChannelListProps> = (args) => <BrowsePageChannelList {...args} />;
+
+export const BlackBrowsePageChannelList = Template.bind({});
+BlackBrowsePageChannelList.args = {
+  channels: [
+    {
+      channelId: 1,
+      title: 'notice',
+      description: '공지사항을 안내하는 채널',
+      isPrivate: false,
+      members: 110,
+      isJoined: true
+    },
+    {
+      channelId: 2,
+      title: '질의응답',
+      isPrivate: false,
+      members: 10,
+      isJoined: false
+    },
+    {
+      channelId: 3,
+      title: 'black',
+      description: 'black',
+      isPrivate: true,
+      members: 3,
+      isJoined: true
+    }
+  ]
+};

--- a/client/src/components/organisms/BrowsePageChannelList/BrowsePageChannelList.tsx
+++ b/client/src/components/organisms/BrowsePageChannelList/BrowsePageChannelList.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+import { BrowsePageChannel } from '@components/organisms';
+
+interface BrowsePageChannelListProps {
+  channels: Array<object>;
+}
+
+const BrowsePageChannelListContainter = styled.div<any>`
+  display: flex;
+  flex-direction: column;
+  overflow-y: scroll;
+  height: 71%;
+`;
+
+const BrowsePageChannelList: React.FC<BrowsePageChannelListProps> = ({ channels, ...props }) => {
+  const createMessages = () => {
+    return channels.map((channel: any) => (
+      <BrowsePageChannel
+        key={channel.chatroomId}
+        title={channel.title}
+        description={channel.description}
+        isPrivate={channel.isPrivate}
+        members={channel.members}
+        isJoined={channel.isJoined}
+      />
+    ));
+  };
+
+  return <BrowsePageChannelListContainter {...props}>{createMessages()}</BrowsePageChannelListContainter>;
+};
+
+export { BrowsePageChannelList, BrowsePageChannelListProps };

--- a/client/src/components/organisms/BrowsePageChannelList/BrowsePageChannelList.tsx
+++ b/client/src/components/organisms/BrowsePageChannelList/BrowsePageChannelList.tsx
@@ -10,6 +10,7 @@ const BrowsePageChannelListContainter = styled.div<any>`
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
+  padding: 0rem 1.5rem;
   height: 71%;
 `;
 

--- a/client/src/components/organisms/index.ts
+++ b/client/src/components/organisms/index.ts
@@ -7,5 +7,17 @@ import { BrowsePageChannel } from './BrowsePageChannel/BrowsePageChannel';
 import { CreateChannelModal } from './CreateChannelModal/CreateChannelModal';
 import { BrowsePageHeader } from './BrowsePageHeader/BrowsePageHeader';
 import { UserBoxModal } from './UserBoxModal/UserBoxModal';
+import { BrowsePageChannelList } from './BrowsePageChannelList/BrowsePageChannelList';
 
-export { Header, Sidebar, ChatroomHeader, ChatroomBody, LoginForm, BrowsePageChannel, CreateChannelModal, BrowsePageHeader, UserBoxModal };
+export {
+  Header,
+  Sidebar,
+  ChatroomHeader,
+  ChatroomBody,
+  LoginForm,
+  BrowsePageChannel,
+  CreateChannelModal,
+  BrowsePageHeader,
+  UserBoxModal,
+  BrowsePageChannelList
+};

--- a/client/src/pages/ChannelBrowser/ChannelBrowser.tsx
+++ b/client/src/pages/ChannelBrowser/ChannelBrowser.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
-import { BrowsePageHeader } from '@components/organisms';
-import { BrowsePageSearchBar } from '@components/molecules';
+import { BrowsePageChannelList, BrowsePageHeader } from '@components/organisms';
+import { BrowsePageControls, BrowsePageSearchBar } from '@components/molecules';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@store/reducers/index';
+import { initChannels } from '@store/actions/channel-action';
 
 interface ChannelBrowserProps {
   children: React.ReactNode;
 }
 
 const ChannelBrowserContainer = styled.div<any>`
+  display: flex;
+  flex-direction: column;
   height: 100%;
 `;
 
@@ -16,12 +21,21 @@ const SearchBarWrap = styled.div<any>`
 `;
 
 const ChannelBrowser: React.FC<ChannelBrowserProps> = ({ children, ...props }) => {
+  const dispatch = useDispatch();
+  const { channelCount, channels } = useSelector((store: RootState) => store.channel);
+
+  useEffect(() => {
+    dispatch(initChannels());
+  }, []);
+
   return (
     <ChannelBrowserContainer {...props}>
       <BrowsePageHeader />
       <SearchBarWrap>
         <BrowsePageSearchBar />
       </SearchBarWrap>
+      <BrowsePageControls channelCount={channelCount} />
+      <BrowsePageChannelList channels={channels} />
     </ChannelBrowserContainer>
   );
 };


### PR DESCRIPTION
## :bookmark_tabs: 제목

Browse Page 채널 목록 구현

관련 이슈: #175

![image](https://user-images.githubusercontent.com/59037261/101855903-9c224180-3ba7-11eb-8d82-e5c557010509.png)


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Browse Page 채널 목록 구현


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Browse Page 접속 시 채널 목록 가져오도록 했습니다.
- Infinite Scroll은 추가 구현이 필요합니다.
- 채널 개수(channelCount)와 사용자가 채팅방에 속해있는지(isJoined)에 대한 정보는 추가적으로 연동이 필요합니다.
