### PR TITLE
feat: messageId를 이용한 replies 조회 api 구현

### DIFF
--- a/server/src/controller/reply-controller.ts
+++ b/server/src/controller/reply-controller.ts
@@ -1,6 +1,7 @@
 import HttpStatusCode from '@constants/http-status-code';
 import { NextFunction, Request, Response } from 'express';
 import ReplyService from '@service/reply-service';
+import messageService from '@service/message-service';
 
 const ReplyController = {
   async createReply(req: Request, res: Response, next: NextFunction) {
@@ -23,14 +24,12 @@ const ReplyController = {
     }
   },
   async getReplies(req: Request, res: Response, next: NextFunction) {
-    const { offsetId } = req.params;
+    const { offsetId } = req.query;
+    const { messageId } = req.params;
     try {
-      if (!offsetId) {
-        const recentReplies = await ReplyService.getInstance().getRecentReplies();
-        res.status(HttpStatusCode.OK).json(recentReplies);
-      }
-      const replies = await ReplyService.getInstance().getRepliesByOffsetId(Number(offsetId));
-      res.status(HttpStatusCode.OK).json(replies);
+      const message = await messageService.getInstance().getMessage(Number(messageId));
+      const replies = await ReplyService.getInstance().getReplies(Number(messageId), Number(offsetId));
+      res.status(HttpStatusCode.OK).json({ message, replies });
     } catch (err) {
       next(err);
     }

--- a/server/src/model/reaction.ts
+++ b/server/src/model/reaction.ts
@@ -1,7 +1,7 @@
 import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, OneToMany, DeleteDateColumn } from 'typeorm';
 import MessageReaction from '@model/message-reaction';
 import ReplyReaction from '@model/reply-reaction';
-import { IsString, IsUrl } from 'class-validator';
+import { IsString } from 'class-validator';
 
 @Entity({ name: 'reaction' })
 export default class Reaction {
@@ -13,7 +13,7 @@ export default class Reaction {
   title: string;
 
   @Column({ length: 100 })
-  @IsUrl()
+  @IsString()
   imageUri: string;
 
   @CreateDateColumn()

--- a/server/src/router/reply-router.ts
+++ b/server/src/router/reply-router.ts
@@ -5,6 +5,6 @@ const router = express.Router();
 
 router.post('/', ReplyController.createReply);
 router.get('/', ReplyController.getReplies);
-router.get('/:offsetId', ReplyController.getReplies);
+router.get('/:messageId', ReplyController.getReplies);
 
 export default router;

--- a/server/src/service/message-service.ts
+++ b/server/src/service/message-service.ts
@@ -56,7 +56,28 @@ class MessageService {
       .where('message.messageId = :messageId', { messageId })
       .getOne();
     if (!message) throw new BadRequestError();
+    this.customMessageReaction(message);
     return message;
+  }
+
+  private async customMessageReaction(message: any) {
+    let messageReactions: any = {};
+    message.messageReactions.forEach((messageReaction) => {
+      const { reactionId, title, imageUri } = messageReaction.reaction;
+      const { displayName } = messageReaction.user;
+      if (messageReactions[reactionId]) {
+        messageReactions[reactionId].replyDisplayNames.push(displayName);
+        messageReactions[reactionId].reactionCount = messageReactions[reactionId].replyDisplayNames.length;
+      } else
+        messageReactions[reactionId] = {
+          reactionId,
+          title,
+          imageUri,
+          reactionCount: 1,
+          replyDisplayNames: [displayName]
+        };
+    });
+    message.messageReactions = messageReactions;
   }
 
   async getMessages(chatroomId: number, offsetId: number) {
@@ -105,12 +126,15 @@ class MessageService {
       message.messageReactions.forEach((messageReaction) => {
         const { reactionId, title, imageUri } = messageReaction.reaction;
         const { displayName } = messageReaction.user;
-        if (messageReactions[reactionId]) messageReactions[reactionId].replyDisplayNames.push(displayName);
-        else
+        if (messageReactions[reactionId]) {
+          messageReactions[reactionId].replyDisplayNames.push(displayName);
+          messageReactions[reactionId].reactionCount = messageReactions[reactionId].replyDisplayNames.length;
+        } else
           messageReactions[reactionId] = {
             reactionId,
             title,
             imageUri,
+            reactionCount: 1,
             replyDisplayNames: [displayName]
           };
       });

--- a/server/src/service/message-service.ts
+++ b/server/src/service/message-service.ts
@@ -46,7 +46,13 @@ class MessageService {
     const message = await this.MessageRepository.createQueryBuilder('message')
       .leftJoinAndSelect('message.user', 'user')
       .leftJoinAndSelect('message.chatroom', 'chatroom')
+      .leftJoin('message.messageReactions', 'messageReactions')
+      .leftJoin('messageReactions.reaction', 'reaction')
+      .leftJoin('messageReactions.user', 'reactionUser')
       .select(['message', 'user.userId', 'user.profileUri', 'user.displayName', 'chatroom.chatroomId'])
+      .addSelect(['messageReactions.messageReactionId'])
+      .addSelect(['reaction.reactionId', 'reaction.title', 'reaction.imageUri'])
+      .addSelect(['reactionUser.displayName'])
       .where('message.messageId = :messageId', { messageId })
       .getOne();
     if (!message) throw new BadRequestError();

--- a/server/src/service/message-service.ts
+++ b/server/src/service/message-service.ts
@@ -66,15 +66,15 @@ class MessageService {
       const { reactionId, title, imageUri } = messageReaction.reaction;
       const { displayName } = messageReaction.user;
       if (messageReactions[reactionId]) {
-        messageReactions[reactionId].replyDisplayNames.push(displayName);
-        messageReactions[reactionId].reactionCount = messageReactions[reactionId].replyDisplayNames.length;
+        messageReactions[reactionId].reactionDisplayNames.push(displayName);
+        messageReactions[reactionId].reactionCount = messageReactions[reactionId].reactionDisplayNames.length;
       } else
         messageReactions[reactionId] = {
           reactionId,
           title,
           imageUri,
           reactionCount: 1,
-          replyDisplayNames: [displayName]
+          reactionDisplayNames: [displayName]
         };
     });
     message.messageReactions = messageReactions;
@@ -127,15 +127,15 @@ class MessageService {
         const { reactionId, title, imageUri } = messageReaction.reaction;
         const { displayName } = messageReaction.user;
         if (messageReactions[reactionId]) {
-          messageReactions[reactionId].replyDisplayNames.push(displayName);
-          messageReactions[reactionId].reactionCount = messageReactions[reactionId].replyDisplayNames.length;
+          messageReactions[reactionId].reactionDisplayNames.push(displayName);
+          messageReactions[reactionId].reactionCount = messageReactions[reactionId].reactionDisplayNames.length;
         } else
           messageReactions[reactionId] = {
             reactionId,
             title,
             imageUri,
             reactionCount: 1,
-            replyDisplayNames: [displayName]
+            reactionDisplayNames: [displayName]
           };
       });
       message.messageReactions = messageReactions;

--- a/server/src/service/reaction-service.ts
+++ b/server/src/service/reaction-service.ts
@@ -21,7 +21,6 @@ class ReactionService {
 
   async createReaction(title: string, imageUri: string) {
     const reaction = await this.reactionRepository.findOne({ title });
-
     if (reaction) {
       throw new BadRequestError();
     }


### PR DESCRIPTION
## :bookmark_tabs: 제목

feat: messageId를 이용한 replies 조회 api 구현

req
```
method: get
uri: /api/replies/:messageId?offsetId
```
res
```
{
    "message": {
        "messageId": number,
        "content": string,
        "createdAt": date,
        "updatedAt": date,
        "deletedAt": date,
        "user": {
            "userId": number,
            "profileUri": string,
            "displayName": string
        },
        "chatroom": {
            "chatroomId": number
        },
        "messageReactions": [
            reactionId(number): {
                "reactionId": number,
                "title": string,
                "imageUri": string,
                "reactionCount": number,
                "reactionDisplayNames": [
                    string
                ]
            }        
        ]
    },
    "replies": [
        {
            "replyId": number,
            "content": string,
            "createdAt": date,
            "updatedAt": date,
            "user": {
                "userId": number,
                "profileUri": string,
                "displayName": string
            },
            "replyReactions": []
        },
   ]
}
```
## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] messageId를 이용한 replies 조회 페이지네이션 구현
- [x] messge Service를 reaction을 포함하기 위해 수정


## :construction: PR 특이 사항

>offsetId가 없다면 가장 최근의 reply를 10개 불러옵니다.
>replies에 replyReacions가 있는데 어차피 사용하지 않은 내용이므로 내부 내용은 포함하지 않았습니다.
