### PR TITLE
feat: Thread Page 연동

### DIFF
--- a/client/src/common/socket/emits/thread.ts
+++ b/client/src/common/socket/emits/thread.ts
@@ -1,0 +1,6 @@
+import { CREATE_REPLY, createThreadState } from '@socket/types/thread-types';
+import socket from '../socketIO';
+
+export const createReply = (reply: createThreadState) => {
+  socket.emit(CREATE_REPLY, reply);
+};

--- a/client/src/common/socket/types/thread-types.ts
+++ b/client/src/common/socket/types/thread-types.ts
@@ -1,0 +1,6 @@
+export const CREATE_REPLY = 'create reply';
+
+export interface createThreadState {
+  content: string;
+  messageId: number | null;
+}

--- a/client/src/common/store/actions/thread-action.ts
+++ b/client/src/common/store/actions/thread-action.ts
@@ -1,0 +1,4 @@
+import { LOAD_THREAD_ASYNC, INSERT_REPLY, replyState } from '@store/types/thread-types';
+
+export const loadThread = (messageId: number) => ({ type: LOAD_THREAD_ASYNC, payload: { messageId } });
+export const InsertReply = (payload: replyState) => ({ type: INSERT_REPLY, payload });

--- a/client/src/common/store/reducers/index.ts
+++ b/client/src/common/store/reducers/index.ts
@@ -3,12 +3,14 @@ import userReducer from './user-reducer';
 import chatroomReducer from './chatroom-reducer';
 import modalReducer from './modal-reducer';
 import channelReducer from './channel-reducer';
+import threadReducer from './thread-reducer';
 
 export const rootReducer = combineReducers({
   user: userReducer,
   chatroom: chatroomReducer,
   modal: modalReducer,
-  channel: channelReducer
+  channel: channelReducer,
+  thread: threadReducer
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/common/store/reducers/thread-reducer.ts
+++ b/client/src/common/store/reducers/thread-reducer.ts
@@ -1,0 +1,40 @@
+import { LOAD_THREAD, threadState, INSERT_REPLY, ThreadTypes } from '@store/types/thread-types';
+
+const initialState: threadState = {
+  message: {
+    messageId: 0,
+    content: '',
+    createdAt: new Date(),
+    updateAt: new Date(),
+    deleteAt: new Date(),
+    user: {
+      userId: 0,
+      profileUri: '',
+      displayName: ''
+    },
+    chatroom: {},
+    messageReactions: []
+  },
+  replies: []
+};
+
+export default function threadReducer(state = initialState, action: ThreadTypes) {
+  switch (action.type) {
+    case LOAD_THREAD:
+      return {
+        ...state,
+        message: action.payload.message,
+        replies: action.payload.replies
+      };
+    case INSERT_REPLY:
+      const newReplies = state.replies;
+      if (action.payload.messageId === state.message.messageId) newReplies.push(action.payload);
+
+      return {
+        ...state,
+        messages: newReplies
+      };
+    default:
+      return state;
+  }
+}

--- a/client/src/common/store/sagas/index.ts
+++ b/client/src/common/store/sagas/index.ts
@@ -2,7 +2,8 @@ import { all } from 'redux-saga/effects';
 import { chatroomSaga } from './chatroom-saga';
 import { userSaga } from './user-saga';
 import { channelSaga } from './channel-saga';
+import { threadSaga } from './thread-saga';
 
 export function* rootSaga() {
-  yield all([chatroomSaga(), userSaga(), channelSaga()]);
+  yield all([chatroomSaga(), userSaga(), channelSaga(), threadSaga()]);
 }

--- a/client/src/common/store/sagas/thread-saga.ts
+++ b/client/src/common/store/sagas/thread-saga.ts
@@ -1,0 +1,17 @@
+import { call, put, takeEvery } from 'redux-saga/effects';
+import API from '@utils/api';
+import { LOAD_THREAD, LOAD_THREAD_ASYNC } from '@store/types/thread-types';
+
+function* loadThreadSaga(action: any) {
+  try {
+    const { messageId } = action.payload;
+    const payload = yield call(API.getThread, messageId);
+    yield put({ type: LOAD_THREAD, payload });
+  } catch (e) {
+    console.log(e);
+  }
+}
+
+export function* threadSaga() {
+  yield takeEvery(LOAD_THREAD_ASYNC, loadThreadSaga);
+}

--- a/client/src/common/store/types/thread-types.ts
+++ b/client/src/common/store/types/thread-types.ts
@@ -1,0 +1,43 @@
+import { userState } from '@store/types/user-types';
+
+export const LOAD_THREAD = 'LOAD_THREAD';
+export const LOAD_THREAD_ASYNC = 'LOAD_THREAD_ASYNC';
+export const INSERT_REPLY = 'INSERT_REPLY';
+
+export interface threadMessageState {
+  messageId: number;
+  content: string;
+  createdAt: Date;
+  updateAt: Date;
+  deleteAt: Date;
+  user: userState;
+  chatroom: Object;
+  messageReactions: any;
+}
+
+export interface replyState {
+  messageId?: number;
+  replyId: number;
+  content: string;
+  createdAt: Date;
+  updateAt: Date;
+  user: userState;
+  replyReactions: Array<object>;
+}
+
+export interface threadState {
+  message: threadMessageState;
+  replies: Array<replyState>;
+}
+
+interface LoadThreadAction {
+  type: typeof LOAD_THREAD;
+  payload: threadState;
+}
+
+interface InsertReply {
+  type: typeof INSERT_REPLY;
+  payload: replyState;
+}
+
+export type ThreadTypes = LoadThreadAction | InsertReply;

--- a/client/src/common/utils/api.ts
+++ b/client/src/common/utils/api.ts
@@ -83,5 +83,10 @@ export default {
   joinChannel: async (chatroomId: number) => {
     const response = await axios.post(`api/user-chatrooms`, { chatroomId });
     return response.data;
+  },
+
+  getThread: async (messageId: number) => {
+    const response = await axios.get(`api/replies/${messageId}`);
+    return response.data;
   }
 };

--- a/client/src/components/molecules/Actionbar/Actionbar.tsx
+++ b/client/src/components/molecules/Actionbar/Actionbar.tsx
@@ -5,8 +5,9 @@ import { color } from '@theme/index';
 import EmojiIcon from '@imgs/emoji-icon.png';
 import ThreadIcon from '@imgs/thread-icon.png';
 import OptionIcon from '@imgs/option-icon.png';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { loadThread } from '@store/actions/thread-action';
 
 interface ActionbarProps {
   messageId: number;
@@ -24,8 +25,10 @@ const ActionbarContainer = styled.div<any>`
 
 const Actionbar: React.FC<ActionbarProps> = ({ messageId, ...props }) => {
   const history = useHistory();
+  const dispatch = useDispatch();
   const chatroomId = useSelector((state: any) => state.chatroom.selectedChatroomId);
   const openThread = () => {
+    dispatch(loadThread(messageId));
     history.push(`/client/${chatroomId}/thread/${messageId}`);
   };
   return (

--- a/client/src/components/molecules/InputReply/InputReply.stories.tsx
+++ b/client/src/components/molecules/InputReply/InputReply.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { InputReply, InputReplyProps } from './InputReply';
+
+export default {
+  title: 'molecules/InputReply',
+  component: InputReply
+} as Meta;
+
+const Template: Story<InputReplyProps> = (args) => <InputReply {...args} />;
+
+export const ThreadInputReply = Template.bind({});
+ThreadInputReply.args = {
+  isThread: true
+};

--- a/client/src/components/molecules/InputReply/InputReply.tsx
+++ b/client/src/components/molecules/InputReply/InputReply.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Input } from '@components/atoms';
+import { color } from '@theme/index';
+import { SendMessageButton } from '@components/molecules';
+import { createReply } from '@socket/emits/thread';
+import { useDispatch } from 'react-redux';
+
+interface InputReplyProps {
+  isThread?: boolean;
+  messageId: number | null;
+}
+
+const InputReplyContainer = styled.div<any>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid ${color.primary};
+  padding: 0.5rem 0rem;
+  width: 100%;
+  max-height: 70%;
+  border-radius: 0.3rem;
+`;
+
+const InputWrap = styled.div<any>`
+  margin-left: 1rem;
+  width: 70%;
+`;
+
+const ButtonWrap = styled.div<any>`
+  margin-right: 1rem;
+`;
+
+const InputReply: React.FC<InputReplyProps> = ({ children, messageId, isThread, ...props }) => {
+  const [content, setContent] = useState('');
+  const dispatch = useDispatch();
+  const sendReply = () => {
+    if (content === '') return;
+    createReply({ content, messageId });
+    setContent('');
+  };
+
+  return (
+    <InputReplyContainer {...props}>
+      <InputWrap>
+        <Input isThread={isThread} content={content} keyPressEnter={sendReply} setContent={setContent} />
+      </InputWrap>
+      <ButtonWrap>
+        <SendMessageButton sendMessage={sendReply} isActive />
+      </ButtonWrap>
+    </InputReplyContainer>
+  );
+};
+
+export { InputReply, InputReplyProps };

--- a/client/src/components/molecules/Message/Message.tsx
+++ b/client/src/components/molecules/Message/Message.tsx
@@ -78,9 +78,14 @@ const Message: React.FC<MessageProps> = ({ messageId, author, thread, content, s
         <Text fontColor={color.primary} size="small">
           {content}
         </Text>
-        {thread.replyCount !== 0 ? (
-          <MessageReplyBar profileImgs={thread.profileUris} replyCount={thread.replyCount} lastRepliedTime={new Date()} onClick={clickThread} />
-        ) : null}
+        {thread.replyCount !== 0 && (
+          <MessageReplyBar
+            profileImgs={thread.profileUris}
+            replyCount={thread.replyCount}
+            lastRepliedTime={new Date(thread.lastReplyAt)}
+            onClick={clickThread}
+          />
+        )}
       </MessageContent>
       {isHover ? <Actionbar messageId={messageId} {...props} /> : null}
     </MessageContainer>

--- a/client/src/components/molecules/Message/Message.tsx
+++ b/client/src/components/molecules/Message/Message.tsx
@@ -1,9 +1,12 @@
 import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { ProfileImg, Text } from '@components/atoms';
-import { Actionbar } from '@components/molecules';
+import { Actionbar, MessageReplyBar } from '@components/molecules';
 import { color } from '@theme/index';
 import { getTimeConversionValue } from '@utils/time';
+import { useHistory } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { loadThread } from '@store/actions/thread-action';
 
 interface MessageProps {
   src: string;
@@ -11,6 +14,7 @@ interface MessageProps {
   content: string;
   messageId: number;
   createdAt: Date;
+  thread: any;
 }
 
 const MessageContainer = styled.div<any>`
@@ -43,14 +47,21 @@ const DateText = styled.p<any>`
   font-size: 0.7rem;
 `;
 
-const Message: React.FC<MessageProps> = ({ messageId, author, content, src, createdAt, ...props }) => {
+const Message: React.FC<MessageProps> = ({ messageId, author, thread, content, src, createdAt, ...props }) => {
   const [isHover, setHover] = useState(false);
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const chatroomId = useSelector((state: any) => state.chatroom.selectedChatroomId);
   const messageContainer = useRef();
   const onMouseEnter = () => {
     setHover(true);
   };
   const onMouseLeave = () => {
     setHover(false);
+  };
+  const clickThread = () => {
+    dispatch(loadThread(messageId));
+    history.push(`/client/${chatroomId}/thread/${messageId}`);
   };
   return (
     <MessageContainer ref={messageContainer} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} {...props}>
@@ -67,6 +78,9 @@ const Message: React.FC<MessageProps> = ({ messageId, author, content, src, crea
         <Text fontColor={color.primary} size="small">
           {content}
         </Text>
+        {thread.replyCount !== 0 ? (
+          <MessageReplyBar profileImgs={thread.profileUris} replyCount={thread.replyCount} lastRepliedTime={new Date()} onClick={clickThread} />
+        ) : null}
       </MessageContent>
       {isHover ? <Actionbar messageId={messageId} {...props} /> : null}
     </MessageContainer>

--- a/client/src/components/molecules/MessageReplyBar/MessageReplyBar.tsx
+++ b/client/src/components/molecules/MessageReplyBar/MessageReplyBar.tsx
@@ -14,11 +14,12 @@ interface MessageReplyBarProps {
 const MessageReplyBarWrap = styled.div<any>`
   display: flex;
   width: 40rem;
-  padding: 0.5rem;
+  margin-top: 0.2rem;
+  padding: 0.2rem;
   border-radius: 0.3rem;
   cursor: pointer;
   &:hover {
-    background-color: ${color.hover_primary};
+    background-color: ${color.tertiary};
   }
 `;
 

--- a/client/src/components/molecules/Reply/Reply.tsx
+++ b/client/src/components/molecules/Reply/Reply.tsx
@@ -1,0 +1,64 @@
+import { RootState } from '@store/reducers';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+import { ProfileImg, Text } from '@components/atoms';
+import { color } from '@theme/index';
+import { getTimeConversionValue } from '@utils/time';
+
+interface ReplyProps {
+  reply: any;
+}
+
+const ReplyContainter = styled.div<any>`
+  display: flex;
+  position: relative;
+  padding: 1rem 1rem;
+  word-break: break-all;
+  &:hover {
+    background-color: ${color.hover_primary};
+  }
+`;
+
+const ProfileImgWrap = styled.div<any>`
+  margin-right: 1.5rem;
+`;
+
+const MessageContent = styled.div<any>`
+  display: flex;
+  flex-direction: column;
+`;
+
+const MessageHeader = styled.div<any>`
+  display: flex;
+  align-items: center;
+`;
+
+const DateText = styled.p<any>`
+  margin: 0 0.3rem;
+  color: gray;
+  font-size: 0.7rem;
+`;
+
+const Reply: React.FC<ReplyProps> = ({ reply }) => {
+  return (
+    <ReplyContainter>
+      <ProfileImgWrap>
+        <ProfileImg size="large" src={reply.user.profileUri} />
+      </ProfileImgWrap>
+      <MessageContent>
+        <MessageHeader>
+          <Text fontColor={color.primary} size="small" isBold={true}>
+            {reply.user.displayName}
+          </Text>
+          <DateText> {getTimeConversionValue(reply.createdAt)}</DateText>
+        </MessageHeader>
+        <Text fontColor={color.primary} size="small">
+          {reply.content}
+        </Text>
+      </MessageContent>
+    </ReplyContainter>
+  );
+};
+
+export { Reply, ReplyProps };

--- a/client/src/components/molecules/index.ts
+++ b/client/src/components/molecules/index.ts
@@ -21,6 +21,8 @@ import { HoverIcon } from './HoverIcon/HoverIcon';
 import { Actionbar } from './Actionbar/Actionbar';
 import { AddChannelButton } from './AddChannelButton/AddChannelButton';
 import { BrowsePageSearchBar } from './BrowsePageSearchBar/BrowsePageSearchBar';
+import { InputReply } from './InputReply/InputReply';
+import { Reply } from './Reply/Reply';
 
 export {
   Actionbar,
@@ -30,6 +32,8 @@ export {
   HoverIcon,
   Section,
   InputMessage,
+  InputReply,
+  Reply,
   SendMessageButton,
   GithubLoginButton,
   Message,

--- a/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
+++ b/client/src/components/organisms/ChatroomBody/ChatroomBody.tsx
@@ -42,6 +42,7 @@ const ChatroomBody: React.FC<ChatroomBodyProps> = ({ title, messages, chatRoomId
         content={message.content}
         src={message.user.profileUri}
         createdAt={message.createdAt}
+        thread={message.thread}
         {...props}></Message>
     ));
   };

--- a/client/src/components/organisms/ThreadBody/ThreadBody.tsx
+++ b/client/src/components/organisms/ThreadBody/ThreadBody.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import { InputReply, Reply } from '@components/molecules';
+import { useSelector } from 'react-redux';
+import { RootState } from '@store/reducers';
+import { ThreadReplies } from './ThreadReplies';
+
+interface ThreadBodyProps {
+  messageId: number | null;
+}
+
+const ThreadBodyContainter = styled.div<any>``;
+
+const InputBoxWrap = styled.div<any>`
+  margin: 1rem;
+`;
+
+const ThreadBody: React.FC<ThreadBodyProps> = ({ messageId }) => {
+  const { message } = useSelector((store: RootState) => store.thread);
+  return (
+    <ThreadBodyContainter>
+      <Reply reply={message} />
+      <ThreadReplies messageId={messageId} />
+      <InputBoxWrap>
+        <InputReply messageId={messageId} isThread />
+      </InputBoxWrap>
+    </ThreadBodyContainter>
+  );
+};
+
+export { ThreadBody, ThreadBodyProps };

--- a/client/src/components/organisms/ThreadBody/ThreadBody.tsx
+++ b/client/src/components/organisms/ThreadBody/ThreadBody.tsx
@@ -9,7 +9,7 @@ interface ThreadBodyProps {
   messageId: number | null;
 }
 
-const ThreadBodyContainter = styled.div<any>``;
+const ThreadBodyContainter = styled.div``;
 
 const InputBoxWrap = styled.div<any>`
   margin: 1rem;

--- a/client/src/components/organisms/ThreadBody/ThreadReplies.tsx
+++ b/client/src/components/organisms/ThreadBody/ThreadReplies.tsx
@@ -1,0 +1,51 @@
+import { Reply } from '@components/molecules';
+import { RootState } from '@store/reducers';
+import { color } from '@theme/index';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
+interface ThreadRepliesProps {
+  messageId: number | null;
+}
+
+const ThreadRepliesContainter = styled.div<any>``;
+
+const ReplyBarContainer = styled.div<any>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ReplyBarText = styled.p<any>`
+  margin: 0;
+  color: ${color.text_primary};
+`;
+
+const ReplyBarLine = styled.div<any>`
+  height: 2px;
+  width: 80%;
+  background-color: ${color.quaternary};
+  margin: 0rem 0.3rem;
+`;
+
+const ThreadReplies: React.FC<ThreadRepliesProps> = () => {
+  const { replies } = useSelector((store: RootState) => store.thread);
+  const createReplies = () => {
+    return replies.map((reply: any) => <Reply reply={reply} />);
+  };
+  const replyLength = replies.length;
+  return (
+    <ThreadRepliesContainter>
+      {replyLength !== 0 ? (
+        <ReplyBarContainer>
+          <ReplyBarText>{replyLength} reply</ReplyBarText>
+          <ReplyBarLine />
+        </ReplyBarContainer>
+      ) : null}
+      {replyLength !== 0 ? createReplies() : null}
+    </ThreadRepliesContainter>
+  );
+};
+
+export { ThreadReplies, ThreadRepliesProps };

--- a/client/src/components/organisms/ThreadBody/ThreadReplies.tsx
+++ b/client/src/components/organisms/ThreadBody/ThreadReplies.tsx
@@ -31,8 +31,9 @@ const ReplyBarLine = styled.div<any>`
 
 const ThreadReplies: React.FC<ThreadRepliesProps> = () => {
   const { replies } = useSelector((store: RootState) => store.thread);
+
   const createReplies = () => {
-    return replies.map((reply: any) => <Reply reply={reply} />);
+    return replies.map((reply: any) => <Reply key={reply.replyId} reply={reply} />);
   };
   const replyLength = replies.length;
   return (

--- a/client/src/components/organisms/index.ts
+++ b/client/src/components/organisms/index.ts
@@ -9,6 +9,7 @@ import { BrowsePageHeader } from './BrowsePageHeader/BrowsePageHeader';
 import { UserBoxModal } from './UserBoxModal/UserBoxModal';
 import { ThreadHeader } from './ThreadHeader/ThreadHeader';
 import { BrowsePageChannelList } from './BrowsePageChannelList/BrowsePageChannelList';
+import { ThreadBody } from './ThreadBody/ThreadBody';
 
 export {
   Header,
@@ -20,6 +21,7 @@ export {
   CreateChannelModal,
   BrowsePageHeader,
   UserBoxModal,
+  ThreadBody,
   ThreadHeader,
   BrowsePageChannelList
 };

--- a/client/src/components/templates/Body.tsx
+++ b/client/src/components/templates/Body.tsx
@@ -4,6 +4,9 @@ import { channelModalClose } from '@store/actions/modal-action';
 import { useDispatch } from 'react-redux';
 import { insertMessage } from '@store/actions/chatroom-action';
 import socket from '@socket/socketIO';
+import { CREATE_MESSAGE } from '@socket/types/message-types';
+import { CREATE_REPLY } from '@socket/types/thread-types';
+import { InsertReply } from '@store/actions/thread-action';
 
 const StyledBody = styled.div`
   position: relative;
@@ -14,8 +17,11 @@ const StyledBody = styled.div`
 const Body: React.FC<any> = ({ children }) => {
   const dispatch = useDispatch();
   useEffect(() => {
-    socket.on('create message', (message: any) => {
+    socket.on(CREATE_MESSAGE, (message: any) => {
       dispatch(insertMessage(message));
+    });
+    socket.on(CREATE_REPLY, (reply: any) => {
+      dispatch(InsertReply(reply));
     });
   }, []);
   const handlingLeave = () => {

--- a/client/src/pages/Chatroom/Chatroom.tsx
+++ b/client/src/pages/Chatroom/Chatroom.tsx
@@ -12,7 +12,7 @@ const ChatroomContainer = styled.div<any>`
   width: -webkit-fill-available;
 `;
 
-const Chatroom: React.FC<ChatroomProps> = ({ children, ...props }) => {
+const Chatroom: React.FC<ChatroomProps> = () => {
   const dispatch = useDispatch();
   const { selectedChatroomId, selectedChatroom, messages } = useSelector((store: RootState) => store.chatroom);
   const { title, users } = selectedChatroom;
@@ -21,9 +21,9 @@ const Chatroom: React.FC<ChatroomProps> = ({ children, ...props }) => {
   }, []);
 
   return (
-    <ChatroomContainer {...props}>
+    <ChatroomContainer>
       <ChatroomHeader title={title} users={users} />
-      <ChatroomBody title={title} messages={messages} chatRoomId={selectedChatroomId} {...props} />
+      <ChatroomBody title={title} messages={messages} chatRoomId={selectedChatroomId} />
     </ChatroomContainer>
   );
 };

--- a/client/src/pages/Chatroom/ChatroomThread.tsx
+++ b/client/src/pages/Chatroom/ChatroomThread.tsx
@@ -9,11 +9,11 @@ const ChatroomThreadContainer = styled.div<any>`
   height: 100%;
 `;
 
-const ChatroomThread: React.FC<ChatroomProps> = ({ ...props }) => {
+const ChatroomThread: React.FC<ChatroomProps> = () => {
   return (
     <ChatroomThreadContainer>
-      <Chatroom {...props} />
-      <Thread {...props} />
+      <Chatroom />
+      <Thread />
     </ChatroomThreadContainer>
   );
 };

--- a/client/src/pages/Chatroom/Thread.tsx
+++ b/client/src/pages/Chatroom/Thread.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { color } from '@theme/index';
-import { ThreadHeader } from '@components/organisms';
+import { ThreadHeader, ThreadBody } from '@components/organisms';
+import { useDispatch, useSelector } from 'react-redux';
+import { loadThread } from '@store/actions/thread-action';
+import { getThreadId } from '@utils/uriParser';
 
 interface ThreadProps {}
 
@@ -12,9 +15,17 @@ const ThreadContainer = styled.div<any>`
 `;
 
 const Thread: React.FC<ThreadProps> = () => {
+  const dispatch = useDispatch();
+  const threadId = getThreadId();
+
+  useEffect(() => {
+    dispatch(loadThread(threadId || 0));
+  }, []);
+
   return (
     <ThreadContainer>
       <ThreadHeader />
+      <ThreadBody messageId={threadId} />
     </ThreadContainer>
   );
 };

--- a/client/src/pages/Chatroom/Thread.tsx
+++ b/client/src/pages/Chatroom/Thread.tsx
@@ -11,7 +11,7 @@ const ThreadContainer = styled.div<any>`
   border-left: 1px solid ${color.border_primary};
 `;
 
-const Thread: React.FC<ThreadProps> = ({ ...props }) => {
+const Thread: React.FC<ThreadProps> = () => {
   return (
     <ThreadContainer>
       <ThreadHeader />

--- a/server/src/socket/handler/reply-handler.ts
+++ b/server/src/socket/handler/reply-handler.ts
@@ -11,15 +11,15 @@ const messageHandler = {
     const newReply = await ReplyService.getInstance().getReply(replyId);
     const replyInfo = await ReplyService.getInstance().getReplyInfo(replyId);
     const { chatroomId } = replyInfo.message.chatroom;
-    io.to(String(chatroomId)).emit(eventName.CREATE_REPLY, { ...newReply, chatroomId });
+    io.to(String(chatroomId)).emit(eventName.CREATE_REPLY, { ...newReply, chatroomId, messageId });
   },
 
   async updateReply(io, socket, reply) {
-    const { replyId, content } = reply;
+    const { replyId, content, messageId } = reply;
     await ReplyService.getInstance().updateReply(replyId, content);
     const replyInfo = await ReplyService.getInstance().getReplyInfo(replyId);
     const { chatroomId } = replyInfo.message.chatroom;
-    io.to(String(chatroomId)).emit(eventName.UPDATE_REPLY, { replyId, content, chatroomId });
+    io.to(String(chatroomId)).emit(eventName.UPDATE_REPLY, { replyId, content, chatroomId, messageId });
   },
 
   async deleteReply(io, socket, reply) {


### PR DESCRIPTION
## :bookmark_tabs: 제목

Thread Page 연동

![image](https://user-images.githubusercontent.com/33643752/102019705-4e305800-3db8-11eb-8d25-eaaad24e3d1a.png)

close #124

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Thread 보내기 Socket 연동
- [x] Thread 상태 관리 로직 설정
- [x] Thread Page 구성


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- PR의 크기가 커지는 것 같아 망각하고 지금 보냅니다...
- 아직 구현되지 않은 내용
     - Thread 무한 스크롤
     - Profile 중복 체크
     - Thread 페이지에서 댓글을 생성했을 때 Chatroom에 반영
- chatroom 메시지 전체 정보를 가져올 때 replies에 마지막 댓글 달린 날짜에 대해서 필요합니다.
