### PR TITLE
feat: replycount 구현

### DIFF
--- a/server/src/controller/reply-controller.ts
+++ b/server/src/controller/reply-controller.ts
@@ -29,6 +29,9 @@ const ReplyController = {
     try {
       const message = await messageService.getInstance().getMessage(Number(messageId));
       const replies = await ReplyService.getInstance().getReplies(Number(messageId), Number(offsetId));
+      const replyCount = await ReplyService.getInstance().getReplyCount(Number(messageId));
+      res.header('Access-Control-Expose-Headers', 'x-total-count');
+      res.setHeader('x-total-count', replyCount);
       res.status(HttpStatusCode.OK).json({ message, replies });
     } catch (err) {
       next(err);

--- a/server/src/service/reply-service.ts
+++ b/server/src/service/reply-service.ts
@@ -126,6 +126,12 @@ class ReplyService {
   async deleteReply(replyId: number) {
     await this.replyRepository.softDelete(replyId);
   }
+
+  async getReplyCount(messageId: number) {
+    const message = await this.messageRepository.findOne({ messageId });
+    const replyCount = await this.replyRepository.count({ message });
+    return replyCount;
+  }
 }
 
 export default ReplyService;


### PR DESCRIPTION
## :bookmark_tabs: 제목

feat: replycount 구현


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] reply-service에 replyCount관련 함수 추가
- [x] reply조회 관련 요청시 응답 ```X-total-count``` 헤더에 댓글 갯수 추가


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 해당 메시지 댓글 조회시  ```X-total-count```  헤더에 해당 메시지의 댓글의 갯수가 전달됩니다.

