### PR TITLE
fix: message가 빈 컨텐츠로 오는 오류 해결

### DIFF
--- a/client/src/common/store/types/message-types.ts
+++ b/client/src/common/store/types/message-types.ts
@@ -4,8 +4,8 @@ import { chatroomThreadState } from './chatroom-types';
 
 export interface messageState {
   messageId: number;
-  createAt: Date;
-  updateAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
   user: userState;
   messageReactions: Array<messageReactionsState>;
   thread: chatroomThreadState;

--- a/client/src/components/templates/Body.tsx
+++ b/client/src/components/templates/Body.tsx
@@ -18,22 +18,7 @@ const Body: React.FC<any> = ({ children }) => {
   const dispatch = useDispatch();
   useEffect(() => {
     socket.on(CREATE_MESSAGE, (message: any) => {
-      dispatch(
-        insertMessage({
-          messageId: message.id,
-          createAt: new Date(),
-          updateAt: new Date(),
-          user: message.user,
-          messageReactions: [],
-          thread: {
-            replyCount: 0,
-            lastReplyAt: null,
-            profileUris: [],
-            files: []
-          },
-          chatroomId: message.chatroomId
-        })
-      );
+      dispatch(insertMessage(message));
     });
     socket.on(CREATE_REPLY, (reply: any) => {
       dispatch(InsertReply(reply));


### PR DESCRIPTION
## :bookmark_tabs: 제목

message가 빈 컨텐츠로 오는 오류 해결


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] message가 빈 컨텐츠로 오는 오류 해결


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- createdAt과 updatedAt에 d가 빠져서 발생한 현상 해결
