### PR TITLE
feat: delete message reaction socket 구현

### DIFF
--- a/server/src/service/message-service.ts
+++ b/server/src/service/message-service.ts
@@ -167,14 +167,13 @@ class MessageService {
   private async customMessagesReplies(messages: any) {
     const maxPrifileUriCount = 5;
     messages.forEach((message: any) => {
-      let lastReplyAtNumber = 0;
+      let lastReplyAt = new Date(0);
       const replyCount = message.replies.length;
       const profileUris = [];
       message.replies.forEach((reply: any) => {
-        lastReplyAtNumber = Math.max(reply.createdAt);
+        lastReplyAt = lastReplyAt < reply.createdAt ? reply.createdAt : lastReplyAt;
         if (profileUris.length < maxPrifileUriCount && !profileUris.includes(reply.user.profileUri)) profileUris.push(reply.user.profileUri);
       });
-      const lastReplyAt = lastReplyAtNumber === 0 ? undefined : new Date(lastReplyAtNumber);
       delete message.replies;
       message.thread = {
         lastReplyAt,

--- a/server/src/service/reply-service.ts
+++ b/server/src/service/reply-service.ts
@@ -77,6 +77,7 @@ class ReplyService {
   }
 
   async getReplies(messageId: number, offsetId: number) {
+    const limit = 20;
     let where = 'reply.messageId = :messageId';
     where += offsetId ? ' AND reply.replyId < :offsetId' : '';
     const replies = await this.replyRepository
@@ -90,7 +91,7 @@ class ReplyService {
       .addSelect(['replyReactions', 'user', 'reaction'])
       .where(where, { messageId, offsetId })
       .orderBy('reply.replyId', 'DESC')
-      .take(10)
+      .take(limit)
       .getMany();
     const formattedReplies = replies.map((reply) => {
       const { replyReactions } = { ...reply };

--- a/server/src/socket/event/message-reaction-event.ts
+++ b/server/src/socket/event/message-reaction-event.ts
@@ -3,6 +3,7 @@ import eventName from '@constants/event-name';
 
 const messageReactionEvent = (io, socket) => {
   socket.on(eventName.CREATE_REACTION, (messageReaction) => messageReactionHandler.createMessageReaction(io, socket, messageReaction));
+  socket.on(eventName.DELETE_REACTION, (messageReaction) => messageReactionHandler.deleteMessageReaction(io, socket, messageReaction));
 };
 
 export default messageReactionEvent;

--- a/server/src/socket/handler/message-reaction-handler.ts
+++ b/server/src/socket/handler/message-reaction-handler.ts
@@ -10,6 +10,16 @@ const messageHandler = {
     const newMessageReaction = await MessageReactionService.getInstance().createMessageReaction(Number(userId), Number(messageId), title, emoji);
     const { chatroomId } = (await MessageServie.getInstance().getMessage(messageId)).chatroom;
     io.to(String(chatroomId)).emit(eventName.CREATE_REACTION, { ...newMessageReaction, chatroomId });
+  },
+
+  async deleteMessageReaction(io, socket, messageReaction) {
+    const req = socket.request;
+    const { userId } = req.user;
+    const { messageId, reactionId } = messageReaction;
+    await MessageReactionService.getInstance().deleteMessageReaction(Number(userId), Number(messageId), Number(reactionId));
+    const newMessageReaction = await MessageReactionService.getInstance().getMessageReaction(Number(messageId), Number(reactionId));
+    const { chatroomId } = (await MessageServie.getInstance().getMessage(messageId)).chatroom;
+    io.to(String(chatroomId)).emit(eventName.DELETE_REACTION, { ...newMessageReaction, chatroomId });
   }
 };
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

feat: delete message reaction socket 구현

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] ```delete reactuon``` event의 socket 구현
- [x] replies 조회 limit 20으로 수정
- [x] ```create reaction``` 응답 프로퍼티명 수정



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- ```create reaction``` 관련해서 명세 수정사항이 있습니다.
- ```create raction```, ```delete reaction``` 관련한 명세는 wiki의 [socket.io 명세서](https://github.com/boostcamp-2020/Project12-B-Slack-Web/wiki/socket.io-%EB%AA%85%EC%84%B8%EC%84%9C)를 참고 부탁드립니다.

