### PR TITLE
feat: join DM socket 구현

### DIFF
--- a/server/src/common/constants/event-name.ts
+++ b/server/src/common/constants/event-name.ts
@@ -3,11 +3,13 @@ const enum eventName {
   UPDATE_MESSAGE = 'update message',
   DELETE_MESSAGE = 'delete message',
   CREATE_REPLY = 'create reply',
-  UPDATE_REPLY = 'update reply',
+  UPDATE_REPLY = 'upda;te reply',
   DELETE_REPLY = 'delete reply',
   JOIN_CHATROOM = 'join chatroom',
   CREATE_CHATROOM = 'create chatroom',
   CREATE_REACTION = 'create reaction',
-  DELETE_REACTION = 'delete reaction'
+  DELETE_REACTION = 'delete reaction',
+  DISCONNECT = 'disconnect',
+  JOIN_DM = 'join DM'
 }
 export default eventName;

--- a/server/src/common/constants/event-name.ts
+++ b/server/src/common/constants/event-name.ts
@@ -3,7 +3,7 @@ const enum eventName {
   UPDATE_MESSAGE = 'update message',
   DELETE_MESSAGE = 'delete message',
   CREATE_REPLY = 'create reply',
-  UPDATE_REPLY = 'upda;te reply',
+  UPDATE_REPLY = 'update reply',
   DELETE_REPLY = 'delete reply',
   JOIN_CHATROOM = 'join chatroom',
   CREATE_CHATROOM = 'create chatroom',

--- a/server/src/model/socket.ts
+++ b/server/src/model/socket.ts
@@ -1,0 +1,15 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import User from '@model/user';
+
+@Entity({ name: 'socket' })
+export default class Socket {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, (user) => user.userId)
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  socketId: string;
+}

--- a/server/src/model/user.ts
+++ b/server/src/model/user.ts
@@ -6,6 +6,7 @@ import Message from '@model/message';
 import MessageReaction from '@model/message-reaction';
 import Reply from '@model/reply';
 import ReplyReaction from '@model/reply-reaction';
+import Socket from '@model/socket';
 
 @Entity({ name: 'user' })
 export default class User {
@@ -63,4 +64,7 @@ export default class User {
 
   @OneToMany(() => ReplyReaction, (replyReaction) => replyReaction.user)
   replyReactions: ReplyReaction[];
+
+  @OneToMany(() => Socket, (socket) => socket.user)
+  sockets: Socket[];
 }

--- a/server/src/repository/socket-repository.ts
+++ b/server/src/repository/socket-repository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from 'typeorm';
+import Socket from '@model/socket';
+
+@EntityRepository(Socket)
+export default class SocketRepository extends Repository<Socket> {}

--- a/server/src/service/socket-service.ts
+++ b/server/src/service/socket-service.ts
@@ -1,0 +1,42 @@
+import { getCustomRepository } from 'typeorm';
+import SocketRepository from '@repository/socket-repository';
+import UserRepository from '@repository/user-repository';
+import validator from '@utils/validator';
+
+class SocketService {
+  static instance: SocketService;
+
+  socketRepository: SocketRepository;
+
+  userRepository: UserRepository;
+
+  constructor() {
+    this.socketRepository = getCustomRepository(SocketRepository);
+    this.userRepository = getCustomRepository(UserRepository);
+  }
+
+  static getInstance(): SocketService {
+    if (!SocketService.instance) {
+      SocketService.instance = new SocketService();
+    }
+    return SocketService.instance;
+  }
+
+  async createSocket(userId, socketId) {
+    const user = await this.userRepository.findOne({ userId });
+    const newSocket = this.socketRepository.create({ user, socketId });
+    await this.socketRepository.save(newSocket);
+  }
+
+  async deleteSocket(socketId) {
+    await this.socketRepository.delete({ socketId });
+  }
+
+  async getSocketId(userId) {
+    const user = await this.userRepository.findOne({ userId });
+    const socketInfos = await this.socketRepository.find({ user });
+    return socketInfos;
+  }
+}
+
+export default SocketService;

--- a/server/src/socket/event/chatroom-event.ts
+++ b/server/src/socket/event/chatroom-event.ts
@@ -3,6 +3,7 @@ import eventName from '@constants/event-name';
 
 const chatroomEvent = (io, socket) => {
   socket.on(eventName.JOIN_CHATROOM, (chatroom) => chatroomHandler.joinChatroom(io, socket, chatroom));
+  socket.on(eventName.JOIN_DM, (DirectMessage) => chatroomHandler.joinDM(io, socket, DirectMessage));
 };
 
 export default chatroomEvent;

--- a/server/src/socket/event/connection-event.ts
+++ b/server/src/socket/event/connection-event.ts
@@ -1,7 +1,9 @@
 import chatroomHandler from '@socket/handler/chatroom-handler';
+import socketHandler from '@socket/handler/socket-handler';
 
 const connectionEvent = (io, socket) => {
   chatroomHandler.initJoinChatroom(io, socket);
+  socketHandler.saveSocketId(io, socket);
 };
 
 export default connectionEvent;

--- a/server/src/socket/event/disconnect-event.ts
+++ b/server/src/socket/event/disconnect-event.ts
@@ -1,0 +1,8 @@
+import socketHandler from '@socket/handler/socket-handler';
+import eventName from '@constants/event-name';
+
+const messageEvent = (io, socket) => {
+  socket.on(eventName.DISCONNECT, () => socketHandler.deleteSocketId(io, socket));
+};
+
+export default messageEvent;

--- a/server/src/socket/handler/chatroom-handler.ts
+++ b/server/src/socket/handler/chatroom-handler.ts
@@ -1,6 +1,7 @@
 import UserChatroomService from '@service/user-chatroom-service';
 import eventName from '@constants/event-name';
 import ChatroomService from '@service/chatroom-service';
+import SocketService from '@service/socket-service';
 
 const chatroomHandler = {
   async initJoinChatroom(io, socket) {
@@ -23,6 +24,14 @@ const chatroomHandler = {
     const { users, userCount } = await ChatroomService.getInstance().getChatroomInfo(chatroomId, userId);
     socket.join(String(chatroomId));
     io.to(String(chatroomId)).emit(eventName.JOIN_CHATROOM, { chatroomId, users, userCount });
+  },
+  async joinDM(io, socket, DirectMessage) {
+    const { chatroomId, userId } = DirectMessage;
+    const socketInfos = await SocketService.getInstance().getSocketId(userId);
+    socketInfos.forEach((socketInfo) => {
+      const { socketId } = socketInfo;
+      io.to(socketId).emit('join DM', { chatroomId });
+    });
   }
 };
 

--- a/server/src/socket/handler/socket-handler.ts
+++ b/server/src/socket/handler/socket-handler.ts
@@ -1,0 +1,17 @@
+import SocketService from '@service/socket-service';
+
+const socketHandler = {
+  async saveSocketId(io, socket) {
+    const req = socket.request;
+    const { userId } = req.user;
+    const socketId = socket.id;
+    SocketService.getInstance().createSocket(userId, socketId);
+  },
+
+  async deleteSocketId(io, socket) {
+    const socketId = socket.id;
+    SocketService.getInstance().deleteSocket(socketId);
+  }
+};
+
+export default socketHandler;

--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -3,9 +3,11 @@ import messageEvent from '@socket/event/message-event';
 import replyEvent from '@socket/event/reply-event';
 import chatroomEvent from '@socket/event/chatroom-event';
 import messageReactionEvent from '@socket/event/message-reaction-event';
+import disconnectEvent from '@socket/event/disconnect-event';
 
 function socketIndex(io, socket) {
   connectionEvent(io, socket);
+  disconnectEvent(io, socket);
   messageEvent(io, socket);
   replyEvent(io, socket);
   chatroomEvent(io, socket);


### PR DESCRIPTION
## :bookmark_tabs: 제목

feat: join DM socket 구현

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] socket model 구현
- [x] socket service 구현
- [x] 연결 시 socketId를 저장, 해제 시 socketId 를 삭제 동작 구현
- [x] join DM 이벤트 발생 시 해당 유저에게 chatroomId를 보내도록 구현


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- socket Id 정보를 가지고 있기 위해 DB에 모델을 추가했습니다.
- 연결 및 해제시 해당 DB에 userId와 socketId가 저장됩니다.
- join DM 이벤트 발생시 소켓을 이용해 해당 유저에게 자신이 할당된 DM 의 chatroomId를 보내줍니다.
- join DM과 관련한 명세는 마찬가지로 WIKI의 socket.io 명세서에서 chatroom 목차를 확인하시면 됩니다.

