### PR TITLE
feat: Profile Modal을 통한 DM 생성 기능 구현

### DIFF
--- a/client/src/common/constants/chat-type.ts
+++ b/client/src/common/constants/chat-type.ts
@@ -1,0 +1,6 @@
+const ChatType = {
+  DM: 'DM',
+  Channel: 'Channel'
+};
+
+export { ChatType };

--- a/client/src/common/constants/index.ts
+++ b/client/src/common/constants/index.ts
@@ -1,5 +1,6 @@
 import { DefaultSectionName } from './default-section-name';
 import { KeyCode } from './key-code';
 import { ScrollEventType } from './scroll-event-type';
+import { ChatType } from './chat-type';
 
-export { DefaultSectionName, KeyCode, ScrollEventType };
+export { DefaultSectionName, KeyCode, ScrollEventType, ChatType };

--- a/client/src/common/store/actions/chatroom-action.ts
+++ b/client/src/common/store/actions/chatroom-action.ts
@@ -4,6 +4,7 @@ import {
   PICK_CHANNEL_ASYNC,
   INSERT_MESSAGE,
   ADD_CHANNEL_ASYNC,
+  ADD_DM_ASYNC,
   RESET_SELECTED_CHANNEL,
   LOAD_NEXT_MESSAGES_ASYNC,
   UPDATE_THREAD,
@@ -15,6 +16,7 @@ export const initSidebarAsync = () => ({ type: INIT_SIDEBAR_ASYNC });
 export const pickChannel = (payload: any) => ({ type: PICK_CHANNEL_ASYNC, payload });
 export const insertMessage = (payload: insertMessageState) => ({ type: INSERT_MESSAGE, payload });
 export const addChannel = (payload: any) => ({ type: ADD_CHANNEL_ASYNC, payload });
+export const addDM = (payload: any) => ({ type: ADD_DM_ASYNC, payload });
 export const resetSelectedChannel = () => ({ type: RESET_SELECTED_CHANNEL });
 export const loadNextMessages = (payload: any) => ({ type: LOAD_NEXT_MESSAGES_ASYNC, payload });
 export const updateThread = (payload: any) => ({ type: UPDATE_THREAD, payload });

--- a/client/src/common/store/reducers/chatroom-reducer.ts
+++ b/client/src/common/store/reducers/chatroom-reducer.ts
@@ -11,6 +11,7 @@ import {
   INIT_SIDEBAR,
   INSERT_MESSAGE,
   ADD_CHANNEL,
+  ADD_DM,
   RESET_SELECTED_CHANNEL,
   LOAD_NEXT_MESSAGES,
   UPDATE_THREAD
@@ -71,6 +72,14 @@ const chatroomReducer = (state = initialState, action: ChatroomTypes) => {
       return {
         ...state,
         channels: newChannels
+      };
+    case ADD_DM:
+      const newDMs = state.directMessages;
+      newDMs.push(action.payload);
+      joinChatroom(action.payload.chatroomId);
+      return {
+        ...state,
+        directMessages: newDMs
       };
     case RESET_SELECTED_CHANNEL:
       const selectedChatroom = {

--- a/client/src/common/store/sagas/chatroom-saga.ts
+++ b/client/src/common/store/sagas/chatroom-saga.ts
@@ -69,6 +69,7 @@ function* addDM(action: any) {
     const chatroomId = yield call(API.createDM, invitedUserId);
     const { profileUri, displayName } = yield call(API.getUser, invitedUserId);
     yield put({ type: ADD_DM, payload: { chatroomId, chatProfileImg: profileUri, chatType: ChatType.DM, title: displayName } });
+    yield put({ type: PICK_CHANNEL_ASYNC, payload: { selectedChatroomId: chatroomId } });
   } catch (e) {
     console.log(e);
   }

--- a/client/src/common/store/sagas/chatroom-saga.ts
+++ b/client/src/common/store/sagas/chatroom-saga.ts
@@ -1,5 +1,6 @@
 import { call, put, takeEvery } from 'redux-saga/effects';
 import API from '@utils/api';
+import { ChatType } from '@constants/index';
 import {
   LOAD,
   LOAD_ASYNC,
@@ -9,6 +10,8 @@ import {
   PICK_CHANNEL_ASYNC,
   ADD_CHANNEL_ASYNC,
   ADD_CHANNEL,
+  ADD_DM_ASYNC,
+  ADD_DM,
   LOAD_NEXT_MESSAGES,
   LOAD_NEXT_MESSAGES_ASYNC
 } from '../types/chatroom-types';
@@ -52,11 +55,22 @@ function* pickChannelSaga(action: any) {
 function* addChannel(action: any) {
   try {
     const chatroomId = yield call(API.createChannel, action.payload.title, action.payload.description, action.payload.isPrivate);
-    const payload = { chatroomId, chatType: 'Channel', isPrivate: action.payload.isPrivate, title: action.payload.title };
+    const payload = { chatroomId, chatType: ChatType.Channel, isPrivate: action.payload.isPrivate, title: action.payload.title };
     yield put({ type: ADD_CHANNEL, payload });
     yield put({ type: PICK_CHANNEL_ASYNC, payload: { selectedChatroomId: chatroomId } });
   } catch (e) {
     alert('같은 이름의 채널이 존재합니다.');
+  }
+}
+
+function* addDM(action: any) {
+  try {
+    const { invitedUserId } = action.payload;
+    const chatroomId = yield call(API.createDM, invitedUserId);
+    const { profileUri, displayName } = yield call(API.getUser, invitedUserId);
+    yield put({ type: ADD_DM, payload: { chatroomId, chatProfileImg: profileUri, chatType: ChatType.DM, title: displayName } });
+  } catch (e) {
+    console.log(e);
   }
 }
 
@@ -75,5 +89,6 @@ export function* chatroomSaga() {
   yield takeEvery(INIT_SIDEBAR_ASYNC, initSidebarSaga);
   yield takeEvery(PICK_CHANNEL_ASYNC, pickChannelSaga);
   yield takeEvery(ADD_CHANNEL_ASYNC, addChannel);
+  yield takeEvery(ADD_DM_ASYNC, addDM);
   yield takeEvery(LOAD_NEXT_MESSAGES_ASYNC, loadNextMessages);
 }

--- a/client/src/common/store/types/chatroom-types.ts
+++ b/client/src/common/store/types/chatroom-types.ts
@@ -9,6 +9,8 @@ export const PICK_CHANNEL_ASYNC = 'PICK_CHANNEL_ASYNC';
 export const INSERT_MESSAGE = 'INSERT_MESSAGE';
 export const ADD_CHANNEL = 'ADD_CHANNEL';
 export const ADD_CHANNEL_ASYNC = 'ADD_CHANNEL_ASYNC';
+export const ADD_DM = 'ADD_DM';
+export const ADD_DM_ASYNC = 'ADD_DM_ASYNC';
 export const RESET_SELECTED_CHANNEL = 'RESET_SELECTED_CHANNEL';
 export const LOAD_NEXT_MESSAGES = 'LOAD_NEXT_MESSAGES';
 export const LOAD_NEXT_MESSAGES_ASYNC = 'LOAD_NEXT_MESSAGES_ASYNC';
@@ -48,6 +50,13 @@ export interface channelState {
   selectedChatroomId: number;
 }
 
+export interface DMState {
+  chatProfileImg: string;
+  chatType: string;
+  chatroomId: number;
+  title: string;
+}
+
 export interface chatroomThreadState {
   replyCount: number;
   lastReplyAt: Date | null;
@@ -60,6 +69,14 @@ export interface addChannelState {
   chatType: string;
   isPrivate: boolean;
   title: string;
+}
+
+export interface addDMState {
+  chatroomId: number;
+  chatProfileImg: string;
+  chatType: string;
+  title: string;
+  invitedUserId: number;
 }
 
 export interface insertMessageState extends messageState {
@@ -96,6 +113,11 @@ interface AddChannelAction {
   payload: addChannelState;
 }
 
+interface AddDMAction {
+  type: typeof ADD_DM;
+  payload: addDMState;
+}
+
 interface ResetSelectedChannel {
   type: typeof RESET_SELECTED_CHANNEL;
 }
@@ -116,6 +138,7 @@ export type ChatroomTypes =
   | PickChannelAction
   | InsertMessageAction
   | AddChannelAction
+  | AddDMAction
   | ResetSelectedChannel
   | LoadNextAction
   | UpdateThread;

--- a/client/src/common/utils/api.ts
+++ b/client/src/common/utils/api.ts
@@ -29,6 +29,11 @@ export default {
     return response.data;
   },
 
+  getUser: async (userId: number) => {
+    const response = await axios.get(`/api/users/${userId}`);
+    return response.data;
+  },
+
   getUserChatroom: async () => {
     const response = await axios.get('/api/user-chatrooms');
     return response.data;
@@ -66,6 +71,16 @@ export default {
       return chatroomId;
     } catch (e) {
       throw new Error('Channel creation failed.');
+    }
+  },
+
+  createDM: async (invitedUserId: number) => {
+    try {
+      const response = await axios.post(`api/chatrooms/dm`, { invitedUserId });
+      const { chatroomId } = response.data;
+      return chatroomId;
+    } catch (e) {
+      throw new Error('DM creation failed.');
     }
   },
 

--- a/client/src/components/molecules/ProfileModal/ProfileModal.tsx
+++ b/client/src/components/molecules/ProfileModal/ProfileModal.tsx
@@ -4,6 +4,8 @@ import { DropMenuBox, ProfileModalImg, Button, ProfileModalBody } from '@compone
 import { color } from '@theme/index';
 import { useDispatch, useSelector } from 'react-redux';
 import { profileModalClose } from '@store/actions/modal-action';
+import { pickChannel } from '@store/actions/chatroom-action';
+import { DMState } from '@store/types/chatroom-types';
 
 interface ProfileModalProps {}
 
@@ -20,12 +22,24 @@ const MessageButtonWrap = styled.div`
 
 const ProfileModal: React.FC<ProfileModalProps> = ({ ...props }) => {
   const dispatch = useDispatch();
-  const { userId, profileUri, displayName } = useSelector((state: any) => state.modal.profileModal);
-  const { x, y } = useSelector((store: any) => store.modal.profileModal);
+  const { x, y, userId, profileUri, displayName } = useSelector((state: any) => state.modal.profileModal);
+  const { directMessages } = useSelector((state: any) => state.chatroom);
   const isOpen = useSelector((store: any) => store.modal.profileModal.isOpen);
 
   const handlingCloseModal = () => {
     dispatch(profileModalClose());
+  };
+
+  const findDirectMessageByTitle = (title: string): DMState => {
+    return directMessages.find((directMessage: DMState) => directMessage.title === title);
+  };
+
+  const handlingMessageButtonClick = () => {
+    dispatch(profileModalClose());
+    const directMessage = findDirectMessageByTitle(displayName);
+    if (directMessage) {
+      dispatch(pickChannel({ selectedChatroomId: directMessage.chatroomId }));
+    }
   };
 
   return (
@@ -42,6 +56,7 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ ...props }) => {
                 fontColor={color.primary}
                 width="100%"
                 height="2rem"
+                onClick={handlingMessageButtonClick}
                 {...props}>
                 Message
               </Button>

--- a/client/src/components/molecules/ProfileModal/ProfileModal.tsx
+++ b/client/src/components/molecules/ProfileModal/ProfileModal.tsx
@@ -4,7 +4,7 @@ import { DropMenuBox, ProfileModalImg, Button, ProfileModalBody } from '@compone
 import { color } from '@theme/index';
 import { useDispatch, useSelector } from 'react-redux';
 import { profileModalClose } from '@store/actions/modal-action';
-import { pickChannel } from '@store/actions/chatroom-action';
+import { addDM, pickChannel } from '@store/actions/chatroom-action';
 import { DMState } from '@store/types/chatroom-types';
 
 interface ProfileModalProps {}
@@ -39,7 +39,9 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ ...props }) => {
     const directMessage = findDirectMessageByTitle(displayName);
     if (directMessage) {
       dispatch(pickChannel({ selectedChatroomId: directMessage.chatroomId }));
+      return;
     }
+    dispatch(addDM({ invitedUserId: userId }));
   };
 
   return (


### PR DESCRIPTION
## :bookmark_tabs: 제목

Profile Modal을 통한 DM 생성 기능 구현

![image](https://user-images.githubusercontent.com/59037261/102170289-57fcad00-3ed7-11eb-9ca3-b5fb6eb5bd11.png)


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Profile Modal을 통한 DM 생성 기능 구현


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 이미 DM이 존재하는 사용자의 Profile Modal Message 버튼 클릭 시 해당 DM으로 이동하도록 구현했습니다.
- DM이 존재하지 않는 사용자의 Profile Modal Message 버튼 클릭 시 DM 생성 후 해당 DM으로 이동하도록 구현했습니다.
- socket을 이용해 상대쪽에 DM 생성을 알리는 기능은 아직 연동이 필요합니다.

