### PR TITLE
feat: Reply 컴포넌트에 Profile Modal Open 동작 추가

### DIFF
--- a/client/src/common/utils/modal.ts
+++ b/client/src/common/utils/modal.ts
@@ -1,13 +1,13 @@
 import { useDispatch } from 'react-redux';
 import { profileModalOpen } from '@store/actions/modal-action';
 
-interface Iuser {
+interface User {
   userId: number;
   profileUri: string;
   displayName: string;
 }
 
-export const openProfileModal = (user: Iuser) => {
+export const openProfileModal = (user: User) => {
   const dispatch = useDispatch();
   return (e: any) => {
     const x = window.pageXOffset + e.target.getBoundingClientRect().left;

--- a/client/src/common/utils/modal.ts
+++ b/client/src/common/utils/modal.ts
@@ -1,0 +1,18 @@
+import { useDispatch } from 'react-redux';
+import { profileModalOpen } from '@store/actions/modal-action';
+
+interface Iuser {
+  userId: number;
+  profileUri: string;
+  displayName: string;
+}
+
+export const openProfileModal = (user: Iuser) => {
+  const dispatch = useDispatch();
+  return (e: any) => {
+    const x = window.pageXOffset + e.target.getBoundingClientRect().left;
+    const y = window.pageYOffset + e.target.getBoundingClientRect().top;
+    const { userId, profileUri, displayName } = user;
+    dispatch(profileModalOpen({ x, y, userId, profileUri, displayName }));
+  };
+};

--- a/client/src/components/molecules/Message/Message.tsx
+++ b/client/src/components/molecules/Message/Message.tsx
@@ -7,7 +7,7 @@ import { getTimeConversionValue } from '@utils/time';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { loadThread } from '@store/actions/thread-action';
-import { profileModalOpen } from '@store/actions/modal-action';
+import { openProfileModal } from '@utils/modal';
 
 interface MessageProps {
   src: string;
@@ -70,20 +70,14 @@ const Message: React.FC<MessageProps> = ({ messageId, author, thread, content, s
     dispatch(loadThread(messageId));
     history.push(`/client/${chatroomId}/thread/${messageId}`);
   };
-  const openProfileModal = (e: any) => {
-    const x = window.pageXOffset + e.target.getBoundingClientRect().left;
-    const y = window.pageYOffset + e.target.getBoundingClientRect().top;
-    const { userId, profileUri, displayName } = user;
-    dispatch(profileModalOpen({ x, y, userId, profileUri, displayName }));
-  };
   return (
     <MessageContainer ref={messageContainer} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} {...props}>
-      <ProfileImgWrap onClick={openProfileModal}>
+      <ProfileImgWrap onClick={openProfileModal(user)}>
         <ProfileImg size="large" src={src} />
       </ProfileImgWrap>
       <MessageContent>
         <MessageHeader>
-          <AuthorWrap onClick={openProfileModal}>
+          <AuthorWrap onClick={openProfileModal(user)}>
             <Text fontColor={color.primary} size="small" isBold={true} isHover={true}>
               {author}
             </Text>

--- a/client/src/components/molecules/Reply/Reply.tsx
+++ b/client/src/components/molecules/Reply/Reply.tsx
@@ -1,10 +1,11 @@
-import { RootState } from '@store/reducers';
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { ProfileImg, Text } from '@components/atoms';
 import { color } from '@theme/index';
 import { getTimeConversionValue } from '@utils/time';
+import { profileModalOpen } from '@store/actions/modal-action';
+import { openProfileModal } from '@utils/modal';
 
 interface ReplyProps {
   reply: any;
@@ -22,6 +23,11 @@ const ReplyContainter = styled.div<any>`
 
 const ProfileImgWrap = styled.div<any>`
   margin-right: 1.5rem;
+  cursor: pointer;
+`;
+
+const AuthorWrap = styled.div`
+  cursor: pointer;
 `;
 
 const MessageContent = styled.div<any>`
@@ -43,14 +49,16 @@ const DateText = styled.p<any>`
 const Reply: React.FC<ReplyProps> = ({ reply }) => {
   return (
     <ReplyContainter>
-      <ProfileImgWrap>
+      <ProfileImgWrap onClick={openProfileModal(reply.user)}>
         <ProfileImg size="large" src={reply.user.profileUri} />
       </ProfileImgWrap>
       <MessageContent>
         <MessageHeader>
-          <Text fontColor={color.primary} size="small" isBold={true}>
-            {reply.user.displayName}
-          </Text>
+          <AuthorWrap onClick={openProfileModal(reply.user)}>
+            <Text fontColor={color.primary} size="small" isBold={true} isHover={true}>
+              {reply.user.displayName}
+            </Text>
+          </AuthorWrap>
           <DateText> {getTimeConversionValue(reply.createdAt)}</DateText>
         </MessageHeader>
         <Text fontColor={color.primary} size="small">


### PR DESCRIPTION
## :bookmark_tabs: 제목

Reply 컴포넌트에 Profile Modal Open 동작 추가


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Reply 컴포넌트에 Profile Modal Open 동작 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Reply 컴포넌트의 profile Img, author 클릭 시 Profile Modal이 open 되도록 했습니다.
- 자주 사용되는 openProfileModal 함수를 utils로 분리했습니다.
