### PR TITLE
feat: websocket으로 사용할 수 있도록 인증 방법 변경

### DIFF
--- a/client/src/common/socket/socketIO.ts
+++ b/client/src/common/socket/socketIO.ts
@@ -3,13 +3,8 @@ import { io } from 'socket.io-client';
 const socketURL: any = process.env.API_URL;
 
 const socket = io(socketURL, {
-  transportOptions: {
-    polling: {
-      extraHeaders: {
-        Authorization: window.localStorage.getItem('token')
-      }
-    }
-  }
+  query: { token: window.localStorage.getItem('token') },
+  transports: ['websocket', 'polling']
 });
 
 export default socket;

--- a/server/src/socket/middleware/jwt.ts
+++ b/server/src/socket/middleware/jwt.ts
@@ -1,7 +1,12 @@
 import passport from 'passport';
 
 const jwtMiddleware = (io) => {
-  const wrap = (middleware) => (socket, next) => middleware(socket.request, {}, next);
+  const wrap = (middleware) => (socket, next) => {
+    const { request } = socket;
+    const { token } = socket.handshake.query;
+    request.headers.authorization = token;
+    middleware(request, {}, next);
+  };
   io.use(wrap(passport.authenticate('jwt', { session: false })));
 };
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

feat: websocket으로 사용할 수 있도록 인증 방법 변경


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 백엔드 코드에서 query로 온 토큰을 req header에 넣도록 변경
- [x] 프론트엔드 코드에서 토큰을 query string으로 주도록 변경 
- [x] 프론트엔드 코드에서 연결방식을 websocket만 사용하도록 변경


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점


