### PR TITLE
feat: leave chatroom 구현

### DIFF
--- a/server/src/common/constants/event-name.ts
+++ b/server/src/common/constants/event-name.ts
@@ -11,7 +11,6 @@ const enum eventName {
   DELETE_REACTION = 'delete reaction',
   DISCONNECT = 'disconnect',
   JOIN_DM = 'join DM',
-  LEAVE_CHANNEL = 'leave channel',
-  UNSUBSCRIBE_CHATROOM = 'unsubscribe chatroom'
+  LEAVE_CHANNEL = 'leave channel'
 }
 export default eventName;

--- a/server/src/common/constants/event-name.ts
+++ b/server/src/common/constants/event-name.ts
@@ -10,6 +10,8 @@ const enum eventName {
   CREATE_REACTION = 'create reaction',
   DELETE_REACTION = 'delete reaction',
   DISCONNECT = 'disconnect',
-  JOIN_DM = 'join DM'
+  JOIN_DM = 'join DM',
+  LEAVE_CHANNEL = 'leave channel',
+  UNSUBSCRIBE_CHATROOM = 'unsubscribe chatroom'
 }
 export default eventName;

--- a/server/src/service/user-chatroom-service.ts
+++ b/server/src/service/user-chatroom-service.ts
@@ -182,6 +182,12 @@ class UserChatroomService {
     await validator(newUserChatroom);
     await this.userChatroomRepository.save(newUserChatroom);
   }
+
+  async leaveChatroom(userId, chatroomId) {
+    const user = await this.userRepository.findOne({ userId });
+    const chatroom = await this.chatroomRepository.findOne({ chatroomId });
+    await this.userChatroomRepository.softDelete({ user, chatroom });
+  }
 }
 
 export default UserChatroomService;

--- a/server/src/socket/event/chatroom-event.ts
+++ b/server/src/socket/event/chatroom-event.ts
@@ -4,6 +4,8 @@ import eventName from '@constants/event-name';
 const chatroomEvent = (io, socket) => {
   socket.on(eventName.JOIN_CHATROOM, (chatroom) => chatroomHandler.joinChatroom(io, socket, chatroom));
   socket.on(eventName.JOIN_DM, (DirectMessage) => chatroomHandler.joinDM(io, socket, DirectMessage));
+  socket.on(eventName.LEAVE_CHANNEL, (chatroom) => chatroomHandler.leaveChatroom(io, socket, chatroom));
+  socket.on(eventName.UNSUBSCRIBE_CHATROOM, (chatroom) => chatroomHandler.unsubscribeChatroom(io, socket, chatroom));
 };
 
 export default chatroomEvent;

--- a/server/src/socket/event/chatroom-event.ts
+++ b/server/src/socket/event/chatroom-event.ts
@@ -5,7 +5,6 @@ const chatroomEvent = (io, socket) => {
   socket.on(eventName.JOIN_CHATROOM, (chatroom) => chatroomHandler.joinChatroom(io, socket, chatroom));
   socket.on(eventName.JOIN_DM, (DirectMessage) => chatroomHandler.joinDM(io, socket, DirectMessage));
   socket.on(eventName.LEAVE_CHANNEL, (chatroom) => chatroomHandler.leaveChatroom(io, socket, chatroom));
-  socket.on(eventName.UNSUBSCRIBE_CHATROOM, (chatroom) => chatroomHandler.unsubscribeChatroom(io, socket, chatroom));
 };
 
 export default chatroomEvent;

--- a/server/src/socket/handler/chatroom-handler.ts
+++ b/server/src/socket/handler/chatroom-handler.ts
@@ -30,8 +30,26 @@ const chatroomHandler = {
     const socketInfos = await SocketService.getInstance().getSocketId(userId);
     socketInfos.forEach((socketInfo) => {
       const { socketId } = socketInfo;
-      io.to(socketId).emit('join DM', { chatroomId });
+      io.to(socketId).emit(eventName.JOIN_DM, { chatroomId });
     });
+  },
+  async leaveChatroom(io, socket, chatroom) {
+    const req = socket.request;
+    const { userId } = req.user;
+    const { chatroomId } = chatroom;
+    await UserChatroomService.getInstance().leaveChatroom(userId, chatroomId);
+    const chatroomInfo = await ChatroomService.getInstance().getChatroomInfo(chatroomId, userId);
+    io.to(String(chatroomId)).emit(eventName.LEAVE_CHANNEL, { ...chatroomInfo, leaveUserId: userId });
+
+    const socketInfos = await SocketService.getInstance().getSocketId(userId);
+    socketInfos.forEach((socketInfo) => {
+      const { socketId } = socketInfo;
+      io.to(socketId).emit(eventName.UNSUBSCRIBE_CHATROOM, { chatroomId });
+    });
+  },
+  async unsubscribeChatroom(io, socket, chatroom) {
+    const { chatroomId } = chatroom;
+    socket.leave(String(chatroomId));
   }
 };
 

--- a/server/src/socket/handler/chatroom-handler.ts
+++ b/server/src/socket/handler/chatroom-handler.ts
@@ -39,7 +39,7 @@ const chatroomHandler = {
     const { chatroomId } = chatroom;
     await UserChatroomService.getInstance().leaveChatroom(userId, chatroomId);
     const chatroomInfo = await ChatroomService.getInstance().getChatroomInfo(chatroomId, userId);
-    io.to(String(chatroomId)).emit(eventName.LEAVE_CHANNEL, { ...chatroomInfo, leaveUserId: userId });
+    io.to(String(chatroomId)).emit(eventName.LEAVE_CHANNEL, { ...chatroomInfo, chatroomId, leaveUserId: userId });
     socket.leave(String(chatroomId));
   }
 };

--- a/server/src/socket/handler/chatroom-handler.ts
+++ b/server/src/socket/handler/chatroom-handler.ts
@@ -40,15 +40,6 @@ const chatroomHandler = {
     await UserChatroomService.getInstance().leaveChatroom(userId, chatroomId);
     const chatroomInfo = await ChatroomService.getInstance().getChatroomInfo(chatroomId, userId);
     io.to(String(chatroomId)).emit(eventName.LEAVE_CHANNEL, { ...chatroomInfo, leaveUserId: userId });
-
-    const socketInfos = await SocketService.getInstance().getSocketId(userId);
-    socketInfos.forEach((socketInfo) => {
-      const { socketId } = socketInfo;
-      io.to(socketId).emit(eventName.UNSUBSCRIBE_CHATROOM, { chatroomId });
-    });
-  },
-  async unsubscribeChatroom(io, socket, chatroom) {
-    const { chatroomId } = chatroom;
     socket.leave(String(chatroomId));
   }
 };


### PR DESCRIPTION
## :bookmark_tabs: 제목

feat: leave chatroom 구현


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] leave chatroom service 구현
- [x] leave chatroom socket 구현
- [x] unsubscribe chatroom 구현


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

### emit
> event name: ```leave channel``` 
```
socket.emit('leave channel',{
    chatroomId: number
    })
```
비고: 해당 사용자가 해당 chatroom에서 떠나도록 DB에서 설정, 해당 챗룸 구독 해제 

### on
> event name: ```leave channel``` 
```
socket.on('leave channel', (chatroom) =>{
        /*deploy code*/
    })
```
chatroom
```
{
  title: string,
  description: number,
  isPrivate: bool,
  chatType: 'Channel',
  topic: string,
  userCount: nmumber,
  users: [
    User {
      userId: number,
      profileUri: string,
      displayName: string
    }
  ],
  chatroomId:number,
  leaveUserId: number
}
```
비고: 사용자가 해당 채팅방을 떠났을 경우 서버로부터 새롭게 갱신된 채팅방의 정보와 떠난 userId를 받음



