### PR TITLE
fix: typeORM 속성 크기 변경

### DIFF
--- a/server/src/model/reaction.ts
+++ b/server/src/model/reaction.ts
@@ -8,11 +8,11 @@ export default class Reaction {
   @PrimaryGeneratedColumn()
   reactionId: number;
 
-  @Column({ length: 30, unique: true })
+  @Column({ length: 100, unique: true })
   @IsString()
   title: string;
 
-  @Column({ length: 100 })
+  @Column({ length: 10 })
   @IsString()
   emoji: string;
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

typeORM 속성 크기 변경


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] title이 30글자가 넘는 경우가 발생해 100글자로 수정
- [x] emoji 글자는 100자까지 필요가 없으므로 10글자로 변경
- [x] 작업 내역 3
- [x] 작업 내역 4


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 이모지를 클릭할 때 추가가 안되는 문제를 해결했습니다 👍 
