### PR TITLE
fix: message reaction, leave chatroom deletedAt관련 문제 수정

### DIFF
--- a/server/src/service/chatroom-service.ts
+++ b/server/src/service/chatroom-service.ts
@@ -117,7 +117,7 @@ class ChatroomService {
       .leftJoin('chatroom.userChatrooms', 'userChatrooms')
       .leftJoin('userChatrooms.user', 'user')
       .select(['chatroom.chatroomId', 'chatroom.title', 'chatroom.description', 'chatroom.isPrivate'])
-      .addSelect(['userChatrooms.userChatroomId', 'userChatrooms.deletedAt'])
+      .addSelect(['userChatrooms.userChatroomId'])
       .addSelect(['user.userId'])
       .orderBy('chatroom.title')
       .getMany();
@@ -131,7 +131,7 @@ class ChatroomService {
     const filterChatrooms = chatrooms.filter((chatroom) => {
       let isJoined = false;
       chatroom.userChatrooms.forEach((userChatroom) => {
-        if (userChatroom.user.userId === userId && userChatroom.deletedAt === null) isJoined = true;
+        if (userChatroom.user.userId === userId) isJoined = true;
       });
       if (isJoined || !chatroom.isPrivate) isJoinedArr.push(isJoined);
       return !chatroom.isPrivate || isJoined;

--- a/server/src/service/message-reaction-service.ts
+++ b/server/src/service/message-reaction-service.ts
@@ -98,7 +98,7 @@ class MessageReactionService {
       throw new NotFoundError();
     }
 
-    await this.messageReactionRepository.softDelete(messageReaction.messageReactionId);
+    await this.messageReactionRepository.delete(messageReaction.messageReactionId);
   }
 
   async getMessageReaction(messageId: number, reactionId: number) {

--- a/server/src/service/user-chatroom-service.ts
+++ b/server/src/service/user-chatroom-service.ts
@@ -186,7 +186,7 @@ class UserChatroomService {
   async leaveChatroom(userId, chatroomId) {
     const user = await this.userRepository.findOne({ userId });
     const chatroom = await this.chatroomRepository.findOne({ chatroomId });
-    await this.userChatroomRepository.softDelete({ user, chatroom });
+    await this.userChatroomRepository.delete({ user, chatroom });
   }
 }
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

fix: message reaction, leave chatroom deletedAt관련 문제 수정


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] messageReaction delete로 변경
- [x] leaveChatroom을 delete로 변경
- [x] getChatroom에서 필요 없어진 null검사 쿼리 제외



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- messageReaction, userChatroom 관련 삭제는 softDelete 적용을 제외했습니다.

