### PR TITLE
refactor: Store Type 네이밍 통일

### DIFF
--- a/client/src/common/store/reducers/chatroom-reducer.ts
+++ b/client/src/common/store/reducers/chatroom-reducer.ts
@@ -3,7 +3,7 @@
 /* eslint-disable no-case-declarations */
 import { uriParser } from '@utils/index';
 import { joinChatroom, joinDM } from '@socket/emits/chatroom';
-import { messageState } from '@store/types/message-types';
+import { MessageState } from '@store/types/message-types';
 import { ReactionsState } from '@store/types/reactions-type';
 import {
   ChatroomState,
@@ -140,7 +140,7 @@ const chatroomReducer = (state = initialState, action: ChatroomTypes) => {
     case UPDATE_THREAD:
       const updateMessages = state.messages;
       const { messageId, profileUri } = action.payload;
-      updateMessages.forEach((message: messageState) => {
+      updateMessages.forEach((message: MessageState) => {
         if (message.messageId === messageId) {
           message.thread.profileUris.push(profileUri);
           message.thread.replyCount += 1;
@@ -154,7 +154,7 @@ const chatroomReducer = (state = initialState, action: ChatroomTypes) => {
     case ADD_MESSAGE_REACTION:
       const addReactionMessages = state.messages;
       if (state.selectedChatroomId === action.payload.chatroomId) {
-        addReactionMessages.forEach((message: messageState) => {
+        addReactionMessages.forEach((message: MessageState) => {
           if (message.messageId === action.payload.messageId) {
             let isExistReaction = false;
             message.messageReactions.forEach((reaction: ReactionsState) => {
@@ -183,7 +183,7 @@ const chatroomReducer = (state = initialState, action: ChatroomTypes) => {
     case DELETE_MESSAGE_REACTION:
       const deleteReactionMessages = state.messages;
       if (state.selectedChatroomId === action.payload.chatroomId) {
-        deleteReactionMessages.forEach((message: messageState) => {
+        deleteReactionMessages.forEach((message: MessageState) => {
           if (message.messageId === action.payload.messageId) {
             message.messageReactions.forEach((reaction: ReactionsState) => {
               if (reaction.reactionId === action.payload.reactionId) {

--- a/client/src/common/store/types/channel-types.ts
+++ b/client/src/common/store/types/channel-types.ts
@@ -47,19 +47,19 @@ interface InitChannelsAction {
   payload: ChannelsState;
 }
 
-interface LoadNextChannels {
+interface LoadNextChannelsAction {
   type: typeof LOAD_NEXT_CHANNELS;
   payload: ChannelsState;
 }
 
-interface JoinChannel {
+interface JoinChannelAction {
   type: typeof JOIN_CHANNEL;
   payload: JoinChannelState;
 }
 
-interface LeaveChannel {
+interface LeaveChannelAction {
   type: typeof LEAVE_CHANNEL;
   payload: LeaveChannelState;
 }
 
-export type ChannelTypes = InitChannelsAction | LoadNextChannels | JoinChannel | LeaveChannel;
+export type ChannelTypes = InitChannelsAction | LoadNextChannelsAction | JoinChannelAction | LeaveChannelAction;

--- a/client/src/common/store/types/chatroom-types.ts
+++ b/client/src/common/store/types/chatroom-types.ts
@@ -1,6 +1,6 @@
 import { socketMessageReactionState } from '@socket/types/reaction-types';
 import { UserState } from '@store/types/user-types';
-import { messageState, messagesState } from './message-types';
+import { MessageState, MessagesState } from './message-types';
 
 export const LOAD = 'LOAD';
 export const LOAD_ASYNC = 'LOAD_ASYNC';
@@ -36,7 +36,7 @@ export interface SelectedChatroomState {
 }
 
 export interface ChatroomState {
-  messages: Array<messageState>;
+  messages: Array<MessageState>;
   selectedChatroom: SelectedChatroomState;
   starred: Array<object>;
   otherSections: Array<object>;
@@ -111,7 +111,7 @@ export interface UpdateChatroomState {
   users: Array<UserState>;
 }
 
-export interface InsertMessageState extends messageState {
+export interface InsertMessageState extends MessageState {
   chatroomId: number;
 }
 
@@ -140,7 +140,7 @@ export interface AsyncJoinDMState {
 
 export interface AsyncLoadNextMessagesState {
   chatroomId: number;
-  offsetMessage: messageState;
+  offsetMessage: MessageState;
 }
 
 export interface AsyncLoad {
@@ -224,7 +224,7 @@ interface ResetSelectedChannelAction {
 
 interface LoadNextMessagesAction {
   type: typeof LOAD_NEXT_MESSAGES;
-  payload: messagesState;
+  payload: MessagesState;
 }
 
 interface UpdateThreadAction {

--- a/client/src/common/store/types/chatroom-types.ts
+++ b/client/src/common/store/types/chatroom-types.ts
@@ -218,26 +218,26 @@ interface LeaveChatroomAction {
   payload: LeaveChatroomState;
 }
 
-interface ResetSelectedChannel {
+interface ResetSelectedChannelAction {
   type: typeof RESET_SELECTED_CHANNEL;
 }
 
-interface LoadNextAction {
+interface LoadNextMessagesAction {
   type: typeof LOAD_NEXT_MESSAGES;
   payload: messagesState;
 }
 
-interface UpdateThread {
+interface UpdateThreadAction {
   type: typeof UPDATE_THREAD;
   payload: UpdateThreadState;
 }
 
-interface AddMessageReaction {
+interface AddMessageReactionAction {
   type: typeof ADD_MESSAGE_REACTION;
   payload: socketMessageReactionState;
 }
 
-interface DeleteMessageReaction {
+interface DeleteMessageReactionAction {
   type: typeof DELETE_MESSAGE_REACTION;
   payload: socketMessageReactionState;
 }
@@ -256,9 +256,9 @@ export type ChatroomTypes =
   | AddDMAction
   | JoinDMAction
   | LeaveChatroomAction
-  | ResetSelectedChannel
-  | LoadNextAction
-  | UpdateThread
-  | AddMessageReaction
-  | DeleteMessageReaction
+  | ResetSelectedChannelAction
+  | LoadNextMessagesAction
+  | UpdateThreadAction
+  | AddMessageReactionAction
+  | DeleteMessageReactionAction
   | UpdateChatroomAction;

--- a/client/src/common/store/types/message-types.ts
+++ b/client/src/common/store/types/message-types.ts
@@ -2,7 +2,7 @@ import { UserState } from './user-types';
 import { ReactionsState } from './reactions-type';
 import { ChatroomThreadState } from './chatroom-types';
 
-export interface messageState {
+export interface MessageState {
   messageId: number;
   createdAt: Date;
   updatedAt: Date;
@@ -11,6 +11,6 @@ export interface messageState {
   thread: ChatroomThreadState;
 }
 
-export interface messagesState {
-  messages: Array<messageState>;
+export interface MessagesState {
+  messages: Array<MessageState>;
 }

--- a/client/src/common/store/types/thread-types.ts
+++ b/client/src/common/store/types/thread-types.ts
@@ -66,24 +66,24 @@ interface LoadThreadAction {
   payload: threadState;
 }
 
-interface InsertReply {
+interface InsertReplyAction {
   type: typeof INSERT_REPLY;
   payload: ReplyState;
 }
 
-interface LoadNextReplies {
+interface LoadNextRepliesAction {
   type: typeof LOAD_NEXT_REPLIES;
   payload: RepliesState;
 }
 
-interface AddReplyReaction {
+interface AddReplyReactionAction {
   type: typeof ADD_REPLY_REACTION;
   payload: socketReplyReactionState;
 }
 
-interface DeleteReplyReaction {
+interface DeleteReplyReactionAction {
   type: typeof DELETE_REPLY_REACTION;
   payload: socketReplyReactionState;
 }
 
-export type ThreadTypes = LoadThreadAction | InsertReply | LoadNextReplies | AddReplyReaction | DeleteReplyReaction;
+export type ThreadTypes = LoadThreadAction | InsertReplyAction | LoadNextRepliesAction | AddReplyReactionAction | DeleteReplyReactionAction;


### PR DESCRIPTION
## :bookmark_tabs: 제목

Store Type 네이밍 통일

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Store Type 네이밍 통일 (Channel, Chatroom, Thread, Message)


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- action interface 네이밍을 `~Action`으로 통일했습니다.
- store type의 네이밍 컨벤션을 파스칼 표기법으로 통일했습니다.
