### PR TITLE
fix: 채팅방/DM 이동 문제 해결

### DIFF
--- a/client/src/common/utils/uriParser.ts
+++ b/client/src/common/utils/uriParser.ts
@@ -24,7 +24,7 @@ export const getThreadId = () => {
   if (threadUrlpattern.test(window.location.pathname)) {
     const pattern = new RegExp(/[0-9]+$/g);
     const code = pattern.exec(window.location.pathname);
-    return code ? Number(code[0]) : -1;
+    return code ? Number(code[0]) : null;
   }
-  return -1;
+  return null;
 };

--- a/client/src/components/organisms/ThreadBody/ThreadBody.tsx
+++ b/client/src/components/organisms/ThreadBody/ThreadBody.tsx
@@ -19,7 +19,7 @@ const ThreadBodyContainter = styled.div`
   height: 90%;
 `;
 
-const InputBoxWrap = styled.div<any>`
+const InputBoxWrap = styled.div`
   margin: 1rem;
 `;
 

--- a/client/src/pages/Chatroom/Thread.tsx
+++ b/client/src/pages/Chatroom/Thread.tsx
@@ -20,13 +20,13 @@ const Thread: React.FC<ThreadProps> = () => {
   const threadId = getThreadId();
 
   useEffect(() => {
-    dispatch(loadThread({ messageId: threadId || 0 }));
+    if (threadId) dispatch(loadThread({ messageId: threadId }));
   }, []);
 
   return (
     <ThreadContainer>
       <ThreadHeader />
-      <ThreadBody messageId={threadId} />
+      {threadId && <ThreadBody messageId={threadId} />}
     </ThreadContainer>
   );
 };


### PR DESCRIPTION
## :bookmark_tabs: 제목

채팅방/DM 이동 문제 해결

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 채팅방/DM 이동 문제 해결

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 채팅방/DM 이동 시 `/thread/-1` 경로가 붙는 문제를 해결했습니다.
- ThreadBody 컴포넌트의 messageId property type이 number이기 때문에 threadId가 null이 아닌 경우에만 ThreadBody 컴포넌트를 렌더링하도록 했습니다.

